### PR TITLE
Bugfix/Fix visibility of claim buttons for host, spectators and players

### DIFF
--- a/assets/scripts/lobby/buttonEventListeners2.js
+++ b/assets/scripts/lobby/buttonEventListeners2.js
@@ -1,6 +1,6 @@
 	
 function redButtonFunction() {
-    if (document.querySelector("#red-button").classList.contains("disabled") === false) {
+    if (document.querySelector("#red-button").classList.contains("hidden") === false) {
         if (isSpectator === true) {
 
         }
@@ -8,7 +8,10 @@ function redButtonFunction() {
 
             if(document.querySelector("#red-button").innerText === "Stand up"){
                 socket.emit("standUpFromGame");
-
+                //remove claim status when a player sits down
+                //then stands up
+                socket.emit("claim", "");
+                
                 enableDisableButtons();
             }
             else{
@@ -74,7 +77,7 @@ function redButtonFunction() {
 
 function greenButtonFunction() {
     //if button is not disabled: 
-    if (document.querySelector("#green-button").classList.contains("disabled") === false) {
+    if (document.querySelector("#green-button").classList.contains("hidden") === false) {
         if (isSpectator === true) {
             socket.emit("join-game", roomId);
         }
@@ -176,7 +179,11 @@ document.querySelector("#backButton").addEventListener("click", function () {
 
 document.querySelector("#claimButton").addEventListener("click", function () {
     //INCOMPLETE
-    socket.emit("claim", "");
+    // disallow innertext change to "unclaim" when spectators
+    // click a disabled claim button
+    if (isSpectator === false) {
+        socket.emit("claim", "");
+    }
 });
 
 

--- a/assets/scripts/lobby/buttonEventListeners2.js
+++ b/assets/scripts/lobby/buttonEventListeners2.js
@@ -1,12 +1,13 @@
 	
 function redButtonFunction() {
-    if (document.querySelector("#red-button").classList.contains("hidden") === false) {
+    // if the button isn't disabled
+    if (document.querySelector("#red-button").classList.contains("disabled") === false) {
         if (isSpectator === true) {
 
         }
         else if (gameStarted === false) {
-
-            if(document.querySelector("#red-button").innerText === "Stand up"){
+            //if we are spectating
+            if(document.querySelector("#red-button").innerText === "Spectate"){
                 socket.emit("standUpFromGame");
                 //remove claim status when a player sits down
                 //then stands up
@@ -14,6 +15,7 @@ function redButtonFunction() {
                 
                 enableDisableButtons();
             }
+            //we are the host, open kick menu
             else{
                 //host kicking
                 // Set the kick modal content
@@ -76,8 +78,8 @@ function redButtonFunction() {
 }
 
 function greenButtonFunction() {
-    //if button is not disabled: 
-    if (document.querySelector("#green-button").classList.contains("hidden") === false) {
+    //if button isn't disabled: 
+    if (document.querySelector("#green-button").classList.contains("disabled") === false) {
         if (isSpectator === true) {
             socket.emit("join-game", roomId);
         }

--- a/assets/scripts/lobby/sockets/game.js
+++ b/assets/scripts/lobby/sockets/game.js
@@ -66,13 +66,13 @@ socket.on("spec-game-starting", function(data){
         allowEnterKey: false
     });
 
-    // document.querySelector("#green-button").classList.contains("disabled")
+    // document.querySelector("#green-button").classList.contains("hidden")
 
-    $("#green-button").addClass("disabled");
+    $("#green-button").addClass("hidden");
 });
 
 socket.on("spec-game-starting-finished", function(data){
-    $("#green-button").removeClass("disabled");
+    $("#green-button").removeClass("hidden");
 });
 
 

--- a/assets/scripts/lobby9.js
+++ b/assets/scripts/lobby9.js
@@ -10,6 +10,14 @@ var socket = io();
 //grab our username from the username assigned by server in EJS file.
 var ownUsername = $("#originalUsername")[0].innerText;
 
+//register all buttons here for easier access
+//less problems on debugging
+var buttons = {
+    "red": "#red-button",
+    "green": "#green-button",
+    "claim": "#claimButton"
+}
+
 setInterval(function(){
     extendTabContentToBottomInRoom();
 
@@ -794,8 +802,11 @@ function drawAndPositionAvatars() {
 
 function drawClaimingPlayers(claimingPlayers){
 
-    $("#claimButton")[0].innerText = "Claim";
-
+    $(buttons["claim"])[0].innerText = "Claim";
+    // Initially when someone creates a room, enable claim button
+    if (isSpectator === false) {
+        $(buttons["claim"]).removeClass("disabled");
+    }
     
     for(var i = 0; i < roomPlayersData.length; i++){
         if(roomPlayersData[i].claim && roomPlayersData[i].claim === true){
@@ -809,7 +820,7 @@ function drawClaimingPlayers(claimingPlayers){
             }
 
             if(roomPlayersData[i].username === ownUsername){
-                $("#claimButton")[0].innerText = "Unclaim";
+                $(buttons["claim"])[0].innerText = "Unclaim";
             }
         }
     }
@@ -857,12 +868,12 @@ function enableDisableButtonsLeader(numPlayersOnMission) {
     // console.log("countHighlightedAvatars: " + countHighlightedAvatars());
     // console.log("numPlayersOnMission: " + numPlayersOnMission);
     if (countHighlightedAvatars() == numPlayersOnMission || (countHighlightedAvatars() + "*") == numPlayersOnMission) {
-        document.querySelector("#green-button").classList.remove("disabled");
-        document.querySelector("#green-button").classList.remove("faded");
+        document.querySelector(buttons["green"]).classList.remove("hidden");
+        document.querySelector(buttons["green"]).classList.remove("disabled");
     }
     else {
-        document.querySelector("#green-button").classList.add("disabled");
-        document.querySelector("#green-button").classList.add("faded");
+        document.querySelector(buttons["green"]).classList.add("hidden");
+        document.querySelector(buttons["green"]).classList.add("disabled");
         
     }
 }
@@ -881,7 +892,7 @@ function enableDisableButtons() {
 
 
     //reset the faded class for the buttons
-    document.querySelector("#green-button").classList.remove("faded");
+    document.querySelector(buttons["green"]).classList.remove("disabled");
     //determine if we are spectator or not
     for(var i = 0; i < roomPlayersData.length; i++){
         if(roomPlayersData[i].username === ownUsername){
@@ -894,45 +905,46 @@ function enableDisableButtons() {
     if (gameStarted === false) {
         //Host
         if (ownUsername === getUsernameFromIndex(0)) {
-            document.querySelector("#green-button").classList.remove("disabled");
-            document.querySelector("#green-button").innerText = "Start";
-
-            document.querySelector("#red-button").classList.remove("disabled");
-            document.querySelector("#red-button").innerText = "Kick";
+            document.querySelector(buttons["green"]).classList.remove("hidden");
+            document.querySelector(buttons["green"]).innerText = "Start";
+            document.querySelector(buttons["claim"]).classList.remove("disabled");
+            document.querySelector(buttons["red"]).classList.remove("hidden");
+            document.querySelector(buttons["red"]).innerText = "Kick";
 
             //set the stuff for the kick modal buttons
-            $("#red-button").attr("data-toggle", "modal");
-            $("#red-button").attr("data-target", "#kickModal");
+            $(buttons["red"]).attr("data-toggle", "modal");
+            $(buttons["red"]).attr("data-target", "#kickModal");
 
             document.querySelector("#options-button").classList.remove("hidden");
         }
         //we are spectator
         else if (isSpectator === true) {
-            document.querySelector("#green-button").classList.remove("disabled");
-            document.querySelector("#green-button").innerText = "Join";
-
-            document.querySelector("#red-button").classList.add("disabled");
-            // document.querySelector("#red-button").innerText = "Disabled";
+            document.querySelector(buttons["green"]).classList.remove("hidden");
+            document.querySelector(buttons["green"]).innerText = "Join";
+            document.querySelector(buttons["claim"]).classList.add("disabled");
+            document.querySelector(buttons["red"]).classList.add("hidden");
+            // document.querySelector(buttons["red"]).innerText = "hidden";
         }
         else {
             disableButtons();
-            document.querySelector("#red-button").classList.remove("disabled");
-            document.querySelector("#red-button").innerText = "Stand up";
+            document.querySelector(buttons["red"]).classList.remove("hidden");
+            document.querySelector(buttons["claim"]).classList.remove("disabled");
+            document.querySelector(buttons["red"]).innerText = "Stand up";
         }
 
         if(ownUsername !== getUsernameFromIndex(0)){
-            $("#red-button").attr("data-toggle", "");
-            $("#red-button").attr("data-target", "");
+            $(buttons["red"]).attr("data-toggle", "");
+            $(buttons["red"]).attr("data-target", "");
         }
     }
     else if (gameStarted === true && isSpectator === false) {
         //if we are in picking phase
         if (gameData.phase === "picking") {
-            document.querySelector("#green-button").classList.add("disabled");
-            document.querySelector("#green-button").innerText = "Pick";
+            document.querySelector(buttons["green"]).classList.add("hidden");
+            document.querySelector(buttons["green"]).innerText = "Pick";
 
-            document.querySelector("#red-button").classList.add("disabled");
-            // document.querySelector("#red-button").innerText = "Disabled";
+            document.querySelector(buttons["red"]).classList.add("hidden");
+            // document.querySelector(buttons["red"]).innerText = "hidden";
 
             if(getUsernameFromIndex(gameData.teamLeader) === ownUsername){
                 showYourTurnNotification(true);
@@ -944,11 +956,11 @@ function enableDisableButtons() {
             if (checkEntryExistsInArray(gameData.playersYetToVote, ownUsername)) {
                 // showYourTurnNotification(true);
 
-                document.querySelector("#green-button").classList.remove("disabled");
-                document.querySelector("#green-button").innerText = "Approve";
+                document.querySelector(buttons["green"]).classList.remove("hidden");
+                document.querySelector(buttons["green"]).innerText = "Approve";
 
-                document.querySelector("#red-button").classList.remove("disabled");
-                document.querySelector("#red-button").innerText = "Reject";
+                document.querySelector(buttons["red"]).classList.remove("hidden");
+                document.querySelector(buttons["red"]).innerText = "Reject";
             }
             else {
                 disableButtons();
@@ -959,11 +971,11 @@ function enableDisableButtons() {
             if (checkEntryExistsInArray(gameData.playersYetToVote, ownUsername)) {
                 // showYourTurnNotification(true);
 
-                document.querySelector("#green-button").classList.remove("disabled");
-                document.querySelector("#green-button").innerText = "SUCCEED";
+                document.querySelector(buttons["green"]).classList.remove("hidden");
+                document.querySelector(buttons["green"]).innerText = "SUCCEED";
 
-                document.querySelector("#red-button").classList.remove("disabled");
-                document.querySelector("#red-button").innerText = "FAIL";
+                document.querySelector(buttons["red"]).classList.remove("hidden");
+                document.querySelector(buttons["red"]).innerText = "FAIL";
             }
             else {
                 disableButtons();
@@ -971,11 +983,11 @@ function enableDisableButtons() {
         }
 
         else if (gameData.phase === "assassination") {
-            // document.querySelector("#green-button").classList.add("disabled");
-            document.querySelector("#green-button").innerText = "SHOOT";
+            // document.querySelector(buttons["green"]).classList.add("hidden");
+            document.querySelector(buttons["green"]).innerText = "SHOOT";
 
-            document.querySelector("#red-button").classList.add("disabled");
-            // document.querySelector("#red-button").innerText = "Disabled";
+            document.querySelector(buttons["red"]).classList.add("hidden");
+            // document.querySelector(buttons["red"]).innerText = "hidden";
 
             if ("Assassin" === gameData.role) {
                 showYourTurnNotification(true);
@@ -983,10 +995,10 @@ function enableDisableButtons() {
 
             //if there is only one person highlighted
             if (countHighlightedAvatars() == 1) {
-                document.querySelector("#green-button").classList.remove("disabled");
+                document.querySelector(buttons["green"]).classList.remove("hidden");
             }
             else {
-                document.querySelector("#green-button").classList.add("disabled");
+                document.querySelector(buttons["green"]).classList.add("hidden");
             }
         }
         else if (gameData.phase === "lady") {
@@ -994,18 +1006,18 @@ function enableDisableButtons() {
                 showYourTurnNotification(true);
             }
             
-            // document.querySelector("#green-button").classList.add("disabled");
-            document.querySelector("#green-button").innerText = "Card";
+            // document.querySelector(buttons["green"]).classList.add("hidden");
+            document.querySelector(buttons["green"]).innerText = "Card";
 
-            document.querySelector("#red-button").classList.add("disabled");
-            // document.querySelector("#red-button").innerText = "Disabled";
+            document.querySelector(buttons["red"]).classList.add("hidden");
+            // document.querySelector(buttons["red"]).innerText = "hidden";
 
             //if there is only one person highlighted
             if (countHighlightedAvatars() == 1 && ownUsername === getUsernameFromIndex(gameData.lady)) {
-                document.querySelector("#green-button").classList.remove("disabled");
+                document.querySelector(buttons["green"]).classList.remove("hidden");
             }
             else {
-                document.querySelector("#green-button").classList.add("disabled");
+                document.querySelector(buttons["green"]).classList.add("hidden");
             }
         }
 
@@ -1029,11 +1041,11 @@ function checkEntryExistsInArray(array, entry) {
 }
 
 function disableButtons() {
-    document.querySelector("#green-button").classList.add("disabled");
-    // document.querySelector("#green-button").innerText = "Disabled";
+    document.querySelector(buttons["green"]).classList.add("hidden");
+    // document.querySelector(buttons["green"]).innerText = "hidden";
 
-    document.querySelector("#red-button").classList.add("disabled");
-    // document.querySelector("#red-button").innerText = "Disabled";
+    document.querySelector(buttons["red"]).classList.add("hidden");
+    // document.querySelector(buttons["red"]).innerText = "hidden";
 }
 
 function countHighlightedAvatars() {
@@ -1917,12 +1929,12 @@ function displayNotification(title, body, icon, tag){
 function showYourTurnNotification(ToF){
     if(ToF === true){
         // $("#statusBarWell").addClass("showYourTurnNotification");
-        $("#green-button").addClass("unhide");
+        $(buttons["green"]).addClass("unhide");
         // $("#statusBarWell").addClass("showFaded");
     }
     else if(ToF === false){
         // $("#statusBarWell").removeClass("showYourTurnNotification");
-        $("#green-button").removeClass("unhide");
+        $(buttons["green"]).removeClass("unhide");
         // $("#statusBarWell").removeClass("showFaded");
     }
     else{

--- a/assets/scripts/lobby9.js
+++ b/assets/scripts/lobby9.js
@@ -865,20 +865,22 @@ function drawClaimingPlayers(claimingPlayers){
   
 function enableDisableButtonsLeader(numPlayersOnMission) {
     //if they've selected the right number of players, then allow them to send
-    // console.log("countHighlightedAvatars: " + countHighlightedAvatars());
-    // console.log("numPlayersOnMission: " + numPlayersOnMission);
     if (countHighlightedAvatars() == numPlayersOnMission || (countHighlightedAvatars() + "*") == numPlayersOnMission) {
-        document.querySelector(buttons["green"]).classList.remove("hidden");
-        document.querySelector(buttons["green"]).classList.remove("disabled");
-    }
-    else {
-        document.querySelector(buttons["green"]).classList.add("hidden");
-        document.querySelector(buttons["green"]).classList.add("disabled");
-        
+        btnRemoveHidden("green");
+        btnRemoveDisabled("green");
     }
 }
 function enableDisableButtons() {
-    showYourTurnNotification(false);
+    //Hide the buttons. Unhide them as we need.
+    document.querySelector(buttons["green"]).classList.add("hidden");
+    document.querySelector(buttons["red"]).classList.add("hidden");
+        // Claim button is never hidden, only disabled
+    // document.querySelector(buttons["claim"]).classList.add("hidden");
+    
+    //Disable the buttons. Enable them as we need them.
+    document.querySelector(buttons["green"]).classList.add("disabled");
+    document.querySelector(buttons["red"]).classList.add("disabled");
+    document.querySelector(buttons["claim"]).classList.add("disabled");
 
     //are we a player sitting down?
     var isPlayer = false;
@@ -886,13 +888,11 @@ function enableDisableButtons() {
         if(roomPlayersData[i].username === ownUsername){
             //if we are a player sitting down, then yes, we are a player
             isPlayer = true;
+            break;
         }
     }
     isSpectator = !isPlayer;
-
-
-    //reset the faded class for the buttons
-    document.querySelector(buttons["green"]).classList.remove("disabled");
+    
     //determine if we are spectator or not
     for(var i = 0; i < roomPlayersData.length; i++){
         if(roomPlayersData[i].username === ownUsername){
@@ -901,15 +901,22 @@ function enableDisableButtons() {
         }
     }
 
+    // if we aren't a spectator, then remove the disable on the claim button
+    if(isSpectator === false){
+        btnRemoveDisabled("claim");
+    }
       
     if (gameStarted === false) {
         //Host
         if (ownUsername === getUsernameFromIndex(0)) {
-            document.querySelector(buttons["green"]).classList.remove("hidden");
-            document.querySelector(buttons["green"]).innerText = "Start";
-            document.querySelector(buttons["claim"]).classList.remove("disabled");
-            document.querySelector(buttons["red"]).classList.remove("hidden");
-            document.querySelector(buttons["red"]).innerText = "Kick";
+
+            btnRemoveHidden("green");
+            btnRemoveDisabled("green");
+            btnSetText("green", "Start");
+
+            btnRemoveHidden("red");
+            btnRemoveDisabled("red");
+            btnSetText("red", "Kick");
 
             //set the stuff for the kick modal buttons
             $(buttons["red"]).attr("data-toggle", "modal");
@@ -919,75 +926,67 @@ function enableDisableButtons() {
         }
         //we are spectator
         else if (isSpectator === true) {
-            document.querySelector(buttons["green"]).classList.remove("hidden");
-            document.querySelector(buttons["green"]).innerText = "Join";
-            document.querySelector(buttons["claim"]).classList.add("disabled");
-            document.querySelector(buttons["red"]).classList.add("hidden");
-            // document.querySelector(buttons["red"]).innerText = "hidden";
+            btnRemoveHidden("green");
+            btnRemoveDisabled("green");
+            btnSetText("green", "Join");
         }
+        //we are a player sitting down, before game has started
         else {
-            disableButtons();
-            document.querySelector(buttons["red"]).classList.remove("hidden");
-            document.querySelector(buttons["claim"]).classList.remove("disabled");
-            document.querySelector(buttons["red"]).innerText = "Stand up";
+            btnRemoveHidden("red");
+            btnRemoveDisabled("red");
+            btnSetText("red", "Spectate");
         }
 
+        //if we are not the host, then un-bind the red button from the kick modal
         if(ownUsername !== getUsernameFromIndex(0)){
             $(buttons["red"]).attr("data-toggle", "");
             $(buttons["red"]).attr("data-target", "");
         }
     }
+    //if game started and we are a player:
     else if (gameStarted === true && isSpectator === false) {
-        //if we are in picking phase
+        // if we are in picking phase
         if (gameData.phase === "picking") {
-            document.querySelector(buttons["green"]).classList.add("hidden");
-            document.querySelector(buttons["green"]).innerText = "Pick";
+            btnSetText("green", "Pick");
 
-            document.querySelector(buttons["red"]).classList.add("hidden");
-            // document.querySelector(buttons["red"]).innerText = "hidden";
-
+            // if we are the team leader, then show them that its their turn by
+            // unhiding the button
             if(getUsernameFromIndex(gameData.teamLeader) === ownUsername){
                 showYourTurnNotification(true);
             }
         }
 
-        //if we are in voting phase
+        // if we are in voting phase
         else if (gameData.phase === "voting") {
+            // if our username is among the players that haven't voted yet
+            // then show the approve reject buttons
             if (checkEntryExistsInArray(gameData.playersYetToVote, ownUsername)) {
-                // showYourTurnNotification(true);
+                btnRemoveHidden("green");
+                btnRemoveDisabled("green");
+                btnSetText("green", "Approve");
 
-                document.querySelector(buttons["green"]).classList.remove("hidden");
-                document.querySelector(buttons["green"]).innerText = "Approve";
-
-                document.querySelector(buttons["red"]).classList.remove("hidden");
-                document.querySelector(buttons["red"]).innerText = "Reject";
-            }
-            else {
-                disableButtons();
+                btnRemoveHidden("red");
+                btnRemoveDisabled("red");
+                btnSetText("red", "Reject");
             }
         }
 
         else if (gameData.phase === "missionVoting") {
+            // if our username is among the players that haven't voted yet
+            // then show the approve reject buttons
             if (checkEntryExistsInArray(gameData.playersYetToVote, ownUsername)) {
-                // showYourTurnNotification(true);
+                btnRemoveHidden("green");
+                btnRemoveDisabled("green");
+                btnSetText("green", "SUCCEED");
 
-                document.querySelector(buttons["green"]).classList.remove("hidden");
-                document.querySelector(buttons["green"]).innerText = "SUCCEED";
-
-                document.querySelector(buttons["red"]).classList.remove("hidden");
-                document.querySelector(buttons["red"]).innerText = "FAIL";
-            }
-            else {
-                disableButtons();
+                btnRemoveHidden("red");
+                btnRemoveDisabled("red");
+                btnSetText("red", "FAIL");
             }
         }
 
         else if (gameData.phase === "assassination") {
-            // document.querySelector(buttons["green"]).classList.add("hidden");
-            document.querySelector(buttons["green"]).innerText = "SHOOT";
-
-            document.querySelector(buttons["red"]).classList.add("hidden");
-            // document.querySelector(buttons["red"]).innerText = "hidden";
+            btnSetText("green", "SHOOT");
 
             if ("Assassin" === gameData.role) {
                 showYourTurnNotification(true);
@@ -995,39 +994,27 @@ function enableDisableButtons() {
 
             //if there is only one person highlighted
             if (countHighlightedAvatars() == 1) {
-                document.querySelector(buttons["green"]).classList.remove("hidden");
-            }
-            else {
-                document.querySelector(buttons["green"]).classList.add("hidden");
+                btnRemoveDisabled("green");
             }
         }
+
         else if (gameData.phase === "lady") {
             if (ownUsername === getUsernameFromIndex(gameData.lady)) {
                 showYourTurnNotification(true);
             }
-            
-            // document.querySelector(buttons["green"]).classList.add("hidden");
-            document.querySelector(buttons["green"]).innerText = "Card";
 
-            document.querySelector(buttons["red"]).classList.add("hidden");
-            // document.querySelector(buttons["red"]).innerText = "hidden";
+            btnSetText("green", "Card");
 
             //if there is only one person highlighted
             if (countHighlightedAvatars() == 1 && ownUsername === getUsernameFromIndex(gameData.lady)) {
-                document.querySelector(buttons["green"]).classList.remove("hidden");
-            }
-            else {
-                document.querySelector(buttons["green"]).classList.add("hidden");
+                btnRemoveDisabled("green");
             }
         }
 
         else if (gameData.phase === "finished") {
+            // Ideally this would be in the draw function somewhere... not here
             drawGuns();
-            disableButtons();
         }
-    }
-    else if (gameStarted === true && isSpectator === true) {
-        disableButtons();
     }
 }
 
@@ -1038,14 +1025,6 @@ function checkEntryExistsInArray(array, entry) {
         }
     }
     return false;
-}
-
-function disableButtons() {
-    document.querySelector(buttons["green"]).classList.add("hidden");
-    // document.querySelector(buttons["green"]).innerText = "hidden";
-
-    document.querySelector(buttons["red"]).classList.add("hidden");
-    // document.querySelector(buttons["red"]).innerText = "hidden";
 }
 
 function countHighlightedAvatars() {
@@ -1927,15 +1906,12 @@ function displayNotification(title, body, icon, tag){
 
 
 function showYourTurnNotification(ToF){
+    //Display the green button if its your turn.
     if(ToF === true){
-        // $("#statusBarWell").addClass("showYourTurnNotification");
-        $(buttons["green"]).addClass("unhide");
-        // $("#statusBarWell").addClass("showFaded");
+        $(buttons["green"]).removeClass("hidden");
     }
     else if(ToF === false){
-        // $("#statusBarWell").removeClass("showYourTurnNotification");
-        $(buttons["green"]).removeClass("unhide");
-        // $("#statusBarWell").removeClass("showFaded");
+        $(buttons["green"]).addClass("hidden");
     }
     else{
         console.log("error in show your turn notifications");
@@ -1964,4 +1940,15 @@ function getGunPos(icon) {
         }
     }
     return position;
+}
+
+
+function btnRemoveHidden(btnStr){
+    document.querySelector(buttons[btnStr]).classList.remove("hidden");
+}
+function btnRemoveDisabled(btnStr){
+    document.querySelector(buttons[btnStr]).classList.remove("disabled");
+}
+function btnSetText(btnStr, text){
+    document.querySelector(buttons[btnStr]).innerText = text;
 }

--- a/assets/stylesheets/lobby.css
+++ b/assets/stylesheets/lobby.css
@@ -999,12 +999,6 @@ i {
     padding-right: 0px;
 }
 
-
-
-
-.disabled{
-    display:none;
-}
 .unhide {
     display: inline !important;
 }
@@ -1019,7 +1013,6 @@ i {
     visibility: visible !important;
     /* display:block; */
 }
-
 
 
 

--- a/gameplay/avalonRoom.js
+++ b/gameplay/avalonRoom.js
@@ -1537,7 +1537,6 @@ module.exports = function (host_, roomId_, io_, maxNumPlayers_, newRoomPassword_
 					avatarImgRes: this.socketsOfPlayers[i].request.user.avatarImgRes,
 					avatarImgSpy: this.socketsOfPlayers[i].request.user.avatarImgSpy,
 					avatarHide: this.socketsOfPlayers[i].request.user.avatarHide,
-					
 					claim: isClaiming
 				}
 	

--- a/sockets/sockets.js
+++ b/sockets/sockets.js
@@ -1735,7 +1735,7 @@ module.exports = function (io) {
 			if (rooms[socket.request.user.inRoomId]) {
 				rooms[socket.request.user.inRoomId].updateMaxNumPlayers(socket, number);
 			}
-                        updateCurrentGamesList();
+			updateCurrentGamesList();
 		});
 
 

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -60,7 +60,7 @@
 			<div class="room-container">
 				<button id="backButton" class="btn btn-warning">Back</button>
 
-				<button id="claimButton" class="btn btn-primary">Claim</button>
+				<button id="claimButton" class="disabled btn btn-primary">Claim</button>
 
 				<div class="gameInfoMaxPlayers badge">
 					8/9


### PR DESCRIPTION
* Closes #14
* fixed visibility of claim buttons for host, spectators and players
* Slight refactor of lobby.css
  - removed .disabled
  - removed .faded
  - changed all objects that used .disabled to .hidden
  - changed all objects that used .faded to .disabled
* lobby9.js
  - new var: buttons{}: for easier referencing in the future (i.e. buttons["red"])