### PR TITLE
Bugfix/claim can be toggled when join/spectate buttons are spammed

### DIFF
--- a/assets/scripts/lobby/buttonEventListeners2.js
+++ b/assets/scripts/lobby/buttonEventListeners2.js
@@ -11,7 +11,7 @@ function redButtonFunction() {
                 socket.emit("standUpFromGame");
                 //remove claim status when a player sits down
                 //then stands up
-                socket.emit("claim", "");
+                socket.emit("setClaim", false);
                 
                 enableDisableButtons();
             }
@@ -184,7 +184,12 @@ document.querySelector("#claimButton").addEventListener("click", function () {
     // disallow innertext change to "unclaim" when spectators
     // click a disabled claim button
     if (isSpectator === false) {
-        socket.emit("claim", "");
+        var btnText = $("#claimButton").text();
+        if (btnText === "Claim"){
+            socket.emit("setClaim", true);
+        } else {
+            socket.emit("setClaim", false);
+        }
     }
 });
 

--- a/gameplay/avalonRoom.js
+++ b/gameplay/avalonRoom.js
@@ -1643,14 +1643,17 @@ module.exports = function (host_, roomId_, io_, maxNumPlayers_, newRoomPassword_
 		return this.gameStarted;
 	}
 
-	this.claim = function(socket){
-		//if the person is already claiming
-		if(socket.request.user.username in this.claimingPlayers){
-			delete this.claimingPlayers[socket.request.user.username];
-		}
-		else{
+	this.setClaim = function(socket, data){
+		//if the player is claiming and is not in claimingPlayers{}
+		if (data === true && Object.keys(this.claimingPlayers).includes(socket.request.user.username) === false){
 			this.claimingPlayers[socket.request.user.username] = true;
-		}
+		  //if the player is unclaiming and is in claimingPlayers{}
+		} else if (data === false && Object.keys(this.claimingPlayers).includes(socket.request.user.username) === true) {
+			delete this.claimingPlayers[socket.request.user.username];
+		} 
+		//if the player is claiming and is in claimingPlayers{}, then do nothing
+		//if the player is unclaiming and is not in claimingPlayers{}, then do nothing
+
 		this.distributeGameData();		
 	}
 	

--- a/sockets/sockets.js
+++ b/sockets/sockets.js
@@ -1797,9 +1797,9 @@ module.exports = function (io) {
 		// 	}
 		// });
 
-		socket.on("claim", function(data){
+		socket.on("setClaim", function(data){
 			if (rooms[socket.request.user.inRoomId]) {
-				rooms[socket.request.user.inRoomId].claim(socket);
+				rooms[socket.request.user.inRoomId].setClaim(socket, data);
 			}
 		});
 


### PR DESCRIPTION
Follow-up: bugfix/claim-button-visibility
* Closes #64
* Fixed bug: claim can be toggled when spamming join/spectate button
* changed this.claim(socket) to this.setClaim(socket, bool data)
  - changed toggling behavior to setting behavior