### PR TITLE
Fixed statsLag

### DIFF
--- a/views/statistics.ejs
+++ b/views/statistics.ejs
@@ -58,6 +58,7 @@
         </div>
 
         <div id="statsDiv" class="hidden">
+            Note: Stats are updated every 10 minutes. This set of statistics was created on: <span id="timeCreated"></span>
 
             <h3>Site traffic (Games played per day):</h3>
             <canvas id="gamesPlayedChart"></canvas>
@@ -284,6 +285,8 @@
         grd = gameRecordsData;
         $("#loading").addClass("hidden");
         $("#statsDiv").removeClass("hidden");
+
+        $("#timeCreated")[0].innerText = new Date(grd.timeCreated).toString();
 
         //***********************************
         //Site traffic stats


### PR DESCRIPTION
Instead of synchronously preparing each set of data to send to the user (40mb of ram each request quickly overflows the 500mb ram limit), prepare one set of data only, and send it out to users when it is ready. This will save ram, processing time, and also reduce database querying.

The data will not update until someone requests it and has passed the minimum time threshold.