### PR TITLE
Add Rogue Role (Chaos22)

### DIFF
--- a/gameplay/avalon/phases/lady.js
+++ b/gameplay/avalon/phases/lady.js
@@ -73,11 +73,14 @@ Lady.prototype.gameMove = function (socket, data) {
             return;
         }
 
-        //grab the target's alliance
+        //grab the target's alliance and role
         var alliance = this.thisRoom.playersInGame[targetIndex].alliance;
-
-        //emit to the lady holder the person's alliance
-        socket.emit("lady-info", /*"Player " + */targetUsername + " is a " + alliance + ".");
+        var role = this.thisRoom.playersInGame[targetIndex].role;
+         //emit to the lady holder the person's alliance unless they're Rogue in which case their role is shown
+        if( role !== "Rogue") {
+            socket.emit("lady-info", /*"Player " + */targetUsername + " is a " + alliance + ".");
+            }
+        else  socket.emit("lady-info", /*"Player " + */targetUsername + " is the Rogue.");
         // console.log("Player " + target + " is a " + alliance);
 
         //update lady location

--- a/gameplay/avalon/roles/rogue.js
+++ b/gameplay/avalon/roles/rogue.js
@@ -1,0 +1,42 @@
+function Rogue(thisRoom_) {
+
+    this.thisRoom = thisRoom_;
+
+    this.role = "Rogue";
+    this.alliance = "Spy";
+
+    this.description = "A spy who cannot fail missions.";
+    this.orderPriorityInOptions = 65;
+
+    //Rogue sees all spies
+    this.see = function () {
+        if (this.thisRoom.gameStarted === true) {
+            var obj = {};
+            var array = [];
+
+            for (var i = 0; i < this.thisRoom.playersInGame.length; i++) {
+                if (this.thisRoom.playersInGame[i].alliance === "Spy") {
+
+                    if (this.thisRoom.playersInGame[i].role === "Oberon") {
+                        //don't add oberon
+                    }
+                    else {
+                     //add the spy
+                        array.push(this.thisRoom.playersInGame[i].username);
+                    }
+                }
+            }
+
+            obj.spies = array;
+            return obj;
+        }
+    }
+
+    this.checkSpecialMove = function () {
+
+    }
+
+}
+
+
+module.exports = Rogue;

--- a/gameplay/commonPhases/votingMission.js
+++ b/gameplay/commonPhases/votingMission.js
@@ -17,10 +17,10 @@ VotingMission.prototype.gameMove = function (socket, data) {
             // console.log("received succeed from " + socket.request.user.username);
         }
         else if (data === "no") {
-            // If the user is a res, they shouldn't be allowed to fail
+            // If the user is a res or rogue, they shouldn't be allowed to fail
             var index = usernamesIndexes.getIndexFromUsername(this.thisRoom.playersInGame, socket.request.user.username);
-            if (index !== -1 && this.thisRoom.playersInGame[index].alliance === "Resistance") {
-                socket.emit("danger-alert", "You are resistance! Surely you want to succeed!");
+            if (index !== -1 && this.thisRoom.playersInGame[index].alliance === "Resistance" || index !== -1 && this.thisRoom.playersInGame[index].role === "Rogue") {
+                socket.emit("danger-alert", "You are "+ this.thisRoom.playersInGame[index].alliance + "! You cannot fail a mission.");
                 return;
             }
 

--- a/gameplay/game.js
+++ b/gameplay/game.js
@@ -387,6 +387,13 @@ Game.prototype.startGame = function (options) {
 	//Get roles:
 	this.resRoles = [];
 	this.spyRoles = [];
+	//Checks whether the Rogue is in play, and if it is, it allows for four spies in 9p
+	var isRogueIncluded =this.spyRoles.includes("Rogue")
+	if(isRogueIncluded == "True") {
+    	this.alliances[8] = "Spy"
+	}
+	else {
+}
 
 	for (var i = 0; i < options.length; i++) {
 		var op = options[i].toLowerCase();


### PR DESCRIPTION
Add role for 'Rogue', a spy who cannot fail missions (replaces a VT). It is carded as 'XXX is a Rogue' rather than 'resistance' or 'spy'. Note: this code was brought to you by Chaos22 and hasn't been tested yet.