### PR TITLE
Highlight picks in the current mission, and outline leader

### DIFF
--- a/assets/stylesheets/lobby.css
+++ b/assets/stylesheets/lobby.css
@@ -407,7 +407,7 @@ p {
 }
 
 .outline-leader {
-    border: 2px solid red;
+    box-shadow: 0 0 3pt 2pt red;
     border-radius: 10px;
 }
 

--- a/assets/stylesheets/lobby.css
+++ b/assets/stylesheets/lobby.css
@@ -377,7 +377,7 @@ p {
 }
 
 
-/* Highlighting of avatars/chat */
+/* Highlighting/outlining of avatars/chat */
 
 .highlight-avatar {
     background-color: #ffff00 !important;
@@ -391,11 +391,25 @@ p {
     border-radius: 10px;
 }
 
+.highlight-pick {
+    background-color: rgb(255, 255, 0) !important;
+    border-radius: 10px;
+}
+
 .highlight-participating-dark {
     background-color: rgba(255, 255, 0, 0.65)  !important;
     border-radius: 10px;
 }
 
+.highlight-pick-dark {
+    background-color: rgba(255, 255, 0, 0.65)  !important;
+    border-radius: 10px;
+}
+
+.outline-leader {
+    border: 2px solid red;
+    border-radius: 10px;
+}
 
 
 .selected-chat {

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -81,11 +81,11 @@
 					</div>
 
 					<div class="row">
-						<div class="pickBox"></div>
-						<div class="pickBox"></div>
-						<div class="pickBox"></div>
-						<div class="pickBox"></div>
-						<div class="pickBox"></div>
+						<div class="pickBox" id="pickBox0"></div>
+						<div class="pickBox" id="pickBox1"></div>
+						<div class="pickBox" id="pickBox2"></div>
+						<div class="pickBox" id="pickBox3"></div>
+						<div class="pickBox" id="pickBox4"></div>
 					</div>
 				</div>
 


### PR DESCRIPTION
This commit adds the ability to highlight previous picks in this mission by hovering over the pick dots, and also changes the highlighting of players to add a border around the leader of the mission.