### PR TITLE
On mobile, don't autocapitalize or autocorrect room passwords

### DIFF
--- a/assets/scripts/lobby/sockets/sockets4.js
+++ b/assets/scripts/lobby/sockets/sockets4.js
@@ -480,6 +480,9 @@ socket.on("joinPassword", function (roomId) {
             input: 'text',
             allowEnterKey: true,
             showCancelButton: true,
+            inputAttributes: {
+                autocapitalize: "off"
+            },
         });
 
         if (inputPassword) {

--- a/assets/scripts/lobby/sockets/sockets4.js
+++ b/assets/scripts/lobby/sockets/sockets4.js
@@ -481,7 +481,9 @@ socket.on("joinPassword", function (roomId) {
             allowEnterKey: true,
             showCancelButton: true,
             inputAttributes: {
-                autocapitalize: "off"
+                autocapitalize: "off",
+                autocomplete: "off",
+                autocorrect: "off",
             },
         });
 

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -630,7 +630,7 @@
 						<option value="10" selected="selected">10</option>
 					</select>
 					<br>
-					<label>Password: <input type="text" name="newRoomPassword" id="newRoomPassword" autocapitalize="off" placeholder="(Optional)" style=""></label>
+					<label>Password: <input type="text" name="newRoomPassword" id="newRoomPassword" autocapitalize="off" autocomplete="off" autocorrect="off" placeholder="(Optional)" style=""></label>
 
 				</div>
 				<div class="modal-footer">

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -630,7 +630,7 @@
 						<option value="10" selected="selected">10</option>
 					</select>
 					<br>
-					<label>Password: <input type="text" name="newRoomPassword" id="newRoomPassword" placeholder="(Optional)" style=""></label>
+					<label>Password: <input type="text" name="newRoomPassword" id="newRoomPassword" autocapitalize="off" placeholder="(Optional)" style=""></label>
 
 				</div>
 				<div class="modal-footer">


### PR DESCRIPTION
This is a super minor inconvenience, but the room password autocapitalizes and autocorrects when creating or joining a room on mobile. While it's not a full fledged password, semantically it makes sense to treat it like one. This change adds the necessary attributes to the password field when creating a room, and passes them into SweetAlert when joining a room, so mobile browsers won't try to autocorrect or autocapitalize or autocomplete.