### PR TITLE
Fixed colors for Tristan and Isolde

### DIFF
--- a/views/profile/profile.ejs
+++ b/views/profile/profile.ejs
@@ -305,7 +305,9 @@ $("#searchButton").on("click", function(e){
             "Mordred": "Spy",
             "Oberon": "Spy",
             "Resistance": "Resistance",
-            "Spy": "Spy"
+            "Spy": "Spy",
+            "Tristan": "Resistance",
+            "Isolde": "Resistance"
         }
 
 


### PR DESCRIPTION
Currently, the statistics on the profile page show red bars for Tristan and Isolde, the lovers. This is a simple fix to the `profile.ejs` view template to correctly show those bars as blue.