### PR TITLE
Fixes spec highlighting bug

### DIFF
--- a/assets/scripts/lobby/chat4.js
+++ b/assets/scripts/lobby/chat4.js
@@ -359,7 +359,7 @@ function addToRoomChat(data) {
 
                 // console.log("true?"  + selectedChat[data[i].username]);
 
-                if (selectedChat[data[i].username] === true && getIndexFromUsername(data[i].username)) {
+                if (selectedChat[data[i].username] === true && getIndexFromUsername(data[i].username) !== undefined) {
                     if (setHighlightColorToYellow === true) {
                         highlightChatColour = "#ffff9e";
                     }

--- a/assets/scripts/lobby/chat4.js
+++ b/assets/scripts/lobby/chat4.js
@@ -359,7 +359,7 @@ function addToRoomChat(data) {
 
                 // console.log("true?"  + selectedChat[data[i].username]);
 
-                if (selectedChat[data[i].username] === true) {
+                if (selectedChat[data[i].username] === true && getIndexFromUsername(data[i].username)) {
                     if (setHighlightColorToYellow === true) {
                         highlightChatColour = "#ffff9e";
                     }


### PR DESCRIPTION
Fixes "bug in my dark-mode highlighting - if you highlit someone and then both go to a new room, the Black foreground stays, but the bg is back to transparent, making it hard to see".

When spectator was lit, he doesnt have a game index, so his highlighting stayed transparent. but it still set the forecolor to black, causing black on black in dark mode.
not spec chat is regular, regardless of having been highlighted or not