### PR TITLE
added change password link to profile

### DIFF
--- a/views/profile/profile.ejs
+++ b/views/profile/profile.ejs
@@ -106,9 +106,10 @@
                             <p>
                                 <% if(userData.username.replace(" ", "") === personViewingUsername.replace(" ", "")) { %>
                                     <a href="<%=userData.username%>/edit" class="btn btn-default">Edit</a>
+                                    <a href="<%=userData.username%>/changepassword" class="btn btn-default">Change password</a>
                                 <% } %>
 
-                            </p>
+                                </p>
                         </span>
                         
                     </div>


### PR DESCRIPTION
The ability for a user to change their password already exists via `/profile/<USERNAME>/changepassword`. I just added a link to this path in their profile.

closes #194 