### PR TITLE
Moderator and Admin Bypass on Private Rooms + Hammer Reject Bug Fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-MY_PLATFORM=local
-MY_SECRET_KEY=AnythingThatYouWant
-DATABASEURL=mongodb://localhost/TheNewResistanceUsers

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+MY_PLATFORM=local
+MY_SECRET_KEY=AnythingThatYouWant
+DATABASEURL=mongodb://localhost/TheNewResistanceUsers

--- a/gameplay/commonPhases/votingTeam.js
+++ b/gameplay/commonPhases/votingTeam.js
@@ -46,6 +46,7 @@ VotingTeam.prototype.gameMove = function (socket, buttonPressed, selectedPlayers
             }
             // Hammer reject
             else if (outcome === 'no' && this.thisRoom.pickNum >= 5) {
+                this.thisRoom.lastProposedTeam = this.thisRoom.proposedTeam;
                 this.thisRoom.missionHistory[this.thisRoom.missionHistory.length] = 'failed';
 
                 this.thisRoom.howWasWon = 'Hammer rejected.';

--- a/gameplay/room.js
+++ b/gameplay/room.js
@@ -69,29 +69,33 @@ function Room(host_, roomId_, io_, maxNumPlayers_, newRoomPassword_, gameMode_) 
 Room.prototype.playerJoinRoom = function (socket, inputPassword) {
     console.log(`${socket.request.user.username} has joined room ${this.roomId}`);
 
-    // if the room has a password and user hasn't put one in yet
-    if (this.joinPassword !== undefined && inputPassword === undefined && (socket.isBotSocket === undefined || socket.isBotSocket === false)) {
-        socket.emit('joinPassword', this.roomId);
-        // console.log("No password inputted!");
+    // check if the player is a moderator or an admin, if so bypass
+    if (!(socket.isModSocket || socket.isAdminSocket)) {
+        // if the room has a password and user hasn't put one in yet
+        if (this.joinPassword !== undefined && inputPassword === undefined && (socket.isBotSocket === undefined || socket.isBotSocket === false)) {
+            socket.emit('joinPassword', this.roomId);
+            // console.log("No password inputted!");
 
-        return false;
-    }
-    // if the room has a password and user HAS put a password in
-    if (this.joinPassword !== undefined && inputPassword !== undefined && (socket.isBotSocket === undefined || socket.isBotSocket === false)) {
-        if (this.joinPassword === inputPassword) {
-            // console.log("Correct password!");
-
-            socket.emit('correctRoomPassword');
-            // continue on
-        } else {
-            // console.log("Wrong password!");
-
-            // socket.emit("danger-alert", "The password you have inputted is incorrect.");
-            socket.emit('wrongRoomPassword');
-            socket.emit('changeView', 'lobby');
             return false;
         }
+        // if the room has a password and user HAS put a password in
+        if (this.joinPassword !== undefined && inputPassword !== undefined && (socket.isBotSocket === undefined || socket.isBotSocket === false)) {
+            if (this.joinPassword === inputPassword) {
+                // console.log("Correct password!");
+
+                socket.emit('correctRoomPassword');
+                // continue on
+            } else {
+                // console.log("Wrong password!");
+
+                // socket.emit("danger-alert", "The password you have inputted is incorrect.");
+                socket.emit('wrongRoomPassword');
+                socket.emit('changeView', 'lobby');
+                return false;
+            }
+        }
     }
+    
 
     this.allSockets.push(socket);
 

--- a/sockets/sockets.js
+++ b/sockets/sockets.js
@@ -1412,6 +1412,28 @@ var actionsObj = {
             }
         },
 
+        mrevealallroles: {
+            command: 'mrevealallroles',
+            help: "/mrevealallroles : Reveals the roles of all players in the current room.",
+            run(data, senderSocket) {
+                const roomId = senderSocket.request.user.inRoomId;
+                if (rooms[roomId]) {
+                    if (!rooms[roomId].gameStarted) {
+                        return { message: `Game has not started.`, classStr: 'server-text' };
+                    }
+                    rooms[roomId].sendText(rooms[roomId].allSockets, `Moderator ${senderSocket.request.user.username} has revealed all roles.`, 'server-text');
+                    
+                    // reveal role for each user
+                    rooms[roomId].playersInGame.forEach((user) => {
+                        senderSocket.emit('messageCommandReturnStr', { message: `${user.username}'s role is ${user.role.toUpperCase()}.`, classStr: 'server-text' });
+                    })
+                    return;
+                }
+                else {
+                    return { message: `You are not in a room.`, classStr: 'server-text' };
+                }
+            }
+        },
     },
 
     adminCommands: {

--- a/sockets/sockets.js
+++ b/sockets/sockets.js
@@ -1611,9 +1611,16 @@ module.exports = function (io) {
             socket.emit('username', socket.request.user.username);
             // send the user the list of commands
             socket.emit('commands', userCommands);
+            
+            // initialise not mod and not admin
+            socket.isModSocket = false;
+            socket.isAdminSocket = false;
 
             // if the mods name is inside the array
             if (modsArray.indexOf(socket.request.user.username.toLowerCase()) !== -1) {
+                // promote to mod socket
+                socket.isModSocket = true;
+                
                 // send the user the list of commands
                 socket.emit('modCommands', modCommands);
 
@@ -1644,6 +1651,9 @@ module.exports = function (io) {
 
             // if the admin name is inside the array
             if (adminsArray.indexOf(socket.request.user.username.toLowerCase()) !== -1) {
+                // promote to admin socket
+                socket.isAdminSocket = true;
+
                 // send the user the list of commands
                 socket.emit('adminCommands', adminCommands);
             }


### PR DESCRIPTION
Allowing moderators and admins to join private rooms without the password. Not sure if there's a better place to promote sockets to admins or mods, if so let me know. Accidentally deleted the .env.example in the first commit and committed all changes so had to add it back, whoops (there's no difference there)

Also a fix for the hammer reject bug that shows the last team instead of the one that was just picked.