### PR TITLE
update docker-compose to use named volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 6379:6379
     entrypoint: redis-server --appendonly yes # Start with data persistance
     volumes:
-      - ./database_data/redis/:/data
+      - redis_data:/data
 
   mongo:
     image: mongo:4.2.3 # Use stable version
@@ -18,7 +18,7 @@ services:
     ports:
       - 27017:27017
     volumes:
-      - ./database_data/mongo/:/data/db
+      - mongo_data:/data/db
 
   # Web interface to access the mongoDB server.
   mongo-express:
@@ -106,3 +106,7 @@ services:
       - ./packages/frontend:/usr/src/app/packages/frontend
       - /usr/src/app/packages/frontend/node_modules
       - /usr/src/app/packages/frontend/.next
+
+volumes:
+  mongo_data:
+  redis_data:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "npm --prefix packages/frontend run lint && npm --prefix packages/backend run lint",
     "test": "npm --prefix packages/frontend test && npm --prefix packages/backend test",
     "test:redis": "docker rm $(docker stop $(docker ps -a -q --filter=\"name=redis-testing\")) ; docker run --name redis-testing -d -p 6379:6379 redis && (npm --prefix packages/frontend test && npm --prefix packages/backend test) ; docker rm $(docker stop $(docker ps -a -q --filter=\"name=redis-testing\"))",
-    "proto": "cp -R proto/* packages/backend/proto && cp -R proto/* packages/frontend/proto"
+    "proto": "cp -R proto/* packages/backend/proto && cp -R proto/* packages/frontend/proto",
+    "reset:db": "docker volume rm proavalon_mongo_data proavalon_redis_data"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- bind mounts did not work with mongo container on windows hosts
- added reset:db npm script to quickly remove volumes