### PR TITLE
add style to make all timestamps the same width

### DIFF
--- a/packages/frontend/components/lobby/mainPanel/message.tsx
+++ b/packages/frontend/components/lobby/mainPanel/message.tsx
@@ -42,6 +42,7 @@ const Message = (props: Props): ReactElement => {
 
           .timestamp {
             color: ${theme.colors.GOLD};
+            font-variant-numeric: tabular-nums;
           }
 
           .pad_left {


### PR DESCRIPTION
- not supported in IE/Edge, but only a minor visual change