### PR TITLE
Adjustments to Rating System

### DIFF
--- a/gameplay/room.js
+++ b/gameplay/room.js
@@ -45,7 +45,7 @@ function Room(host_, roomId_, io_, maxNumPlayers_, newRoomPassword_, gameMode_, 
         this.gameMode = 'avalon';
     }
     this.ranked = ranked_;
-    this.gamesRequiredForRanked = 50;
+    this.gamesRequiredForRanked = 5;
     this.provisionalGamesRequired = 20;
 
     // Misc. variables

--- a/sockets/sockets.js
+++ b/sockets/sockets.js
@@ -2679,7 +2679,7 @@ var updateCurrentPlayersList = function () {
     for (let i = 0; i < allSockets.length; i++) {
         playerList[i] = {};
         playerList[i].displayUsername = allSockets[i].request.displayUsername ? allSockets[i].request.displayUsername : allSockets[i].request.user.username;
-        playerList[i].playerRating = Math.round(allSockets[i].request.user.playerRating);
+        playerList[i].playerRating = Math.floor(allSockets[i].request.user.playerRating);
         playerList[i].ratingBracket = allSockets[i].request.user.ratingBracket;
         playerList[i].ratingBadge = allSockets[i].request.ratingBadge;
     }


### PR DESCRIPTION
- ✅Adjust elo calculations and provisional changes to use different player size winrates.
- ✅Update provisional changes to have a maximum increase or decrease to prevent extreme ballooning.
- ✅Update provisional team adjustments to work for all player sizes.
- ✅Smooth out the elo calculations to make it slightly less aggressive, lower to division by 500.
- ✅Adjust rounding to flooring to prevent number issues with ranks on boundaries.
- ✅Lower the amount of unranked games required for ranked games to 5.