### PR TITLE
Prevent Sire of the Sea from running after hammer rejects

### DIFF
--- a/src/gameplay/avalon/cards/sire of the sea.js
+++ b/src/gameplay/avalon/cards/sire of the sea.js
@@ -56,6 +56,7 @@ class SireOfTheSea {
 
     if (
       this.thisRoom.missionHistory.length >= 2 &&
+      this.thisRoom.howWasWon !== 'Hammer rejected.' &&
       this.lastMissionUsed !== this.thisRoom.missionNum &&
       numSuccess < 3 &&
       numFail < 3


### PR DESCRIPTION
Fixes #403: check for hammer reject as in lady of the lake and ref of the rain code.