### PR TITLE
Add the most important glossary for new players

### DIFF
--- a/assets/scripts/lobby/glossary.js
+++ b/assets/scripts/lobby/glossary.js
@@ -134,6 +134,7 @@ const definitions = {
   'vote': '1. Approve or reject. 2. Succeed or fail. 3. An approve or reject. 4. A success or fail.',
   'vh': 'Vote history; The history of all picks, votes, and missions in the game, accessible in the bottom tab on proavalon.com.',
   'vote history': 'The history of all picks, votes, and missions in the game, accessible in the bottom tab on proavalon.com.',
+  'who': 'We reject new players in ProAvalon.',
   '5p': 'A game with 5 players.',
   '6p': 'A game with 6 players.',
   '7p': 'A game with 7 players.',


### PR DESCRIPTION
The glossary "who" is essential for new players. New players are always facing the word "who" from the regular players, and even by the moderators. After saying the word "who", the regular players and moderators would either kick the new players or recreate a game without the new players. New players may not realize such toxic behavior from regular players and moderators. Adding the glossary of "who" helps the new players understand the situation.