### PR TITLE
Update settings.ts to set registration as default off

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,7 @@
 // Global settings that can be controlled through commands
 
 class Settings {
-  private disableRegistration = false;
+  private disableRegistration = true;
 
   getDisableRegistration(): boolean {
     return this.disableRegistration;


### PR DESCRIPTION
This is the simplest way to foil spammers' ability to make accounts whenever site has to restart for some reason and registration automatically switches back on.