### PR TITLE
Sort games by game status to have the newest games show up first

### DIFF
--- a/assets/scripts/lobby/sockets/sockets.js
+++ b/assets/scripts/lobby/sockets/sockets.js
@@ -368,6 +368,11 @@ socket.on('update-current-players-list', (currentPlayers) => {
   $('.player-count').text(currentPlayers.length);
 });
 
+// Defines the order in which the game statuses will be sorted. If there is a new game status that is not
+// in the object, it will default to the last position.
+const gameStatusOrder = { 'Waiting': 0, 'Game in progress': 1, 'Paused': 2, 'Frozen': 3, 'Finished': 4 };
+const defaultGameOrder = Object.keys(gameStatusOrder).length;
+
 socket.on('update-current-games-list', (currentGames) => {
   // remove all the entries inside the table:
   $('#current-games-table tbody tr td').remove();
@@ -375,10 +380,13 @@ socket.on('update-current-games-list', (currentGames) => {
 
   $('.games-count').text(currentGames.filter((game) => game).length);
 
-  // append each game to the list
-  currentGames.forEach((currentGame) => {
-    // if the current game exists, add it
-    if (currentGame) {
+  currentGames
+    // filter games that exist
+    .filter(currentGame => currentGame)
+    // sort the games by status so that games in progress show first and games that have finished show last.
+    .sort((a, b) => (gameStatusOrder[a.status] ?? defaultGameOrder) - (gameStatusOrder[b.status] ?? defaultGameOrder))
+    // append each game to the list
+    .forEach((currentGame) => {
       let lockStr = '';
       if (currentGame.passwordLocked === true) {
         lockStr = " <span class='glyphicon glyphicon-lock'></span>";
@@ -434,8 +442,7 @@ socket.on('update-current-games-list', (currentGames) => {
 
         joinRoom(currentGame.roomId);
       });
-    }
-  });
+    });
 
   // remove the ugly remaining border when no games are there to display
   if (
@@ -525,8 +532,7 @@ socket.on('update-room-players', (data) => {
     ) {
       displayNotification(
         `New player in game!  [${roomPlayersData.length}p]`,
-        `${
-          roomPlayersData[roomPlayersData.length - 1].username
+        `${roomPlayersData[roomPlayersData.length - 1].username
         } has joined the game!`,
         'avatars/base-res.png',
         'newPlayerInGame'
@@ -628,7 +634,7 @@ socket.on('update-room-spectators', (spectatorUsernames) => {
 
 socket.on('joinPassword', (roomId) => {
   (async function getEmail() {
-    const {value: inputPassword} = await swal({
+    const { value: inputPassword } = await swal({
       title: 'Type in the room password',
       type: 'info',
       input: 'text',

--- a/src/views/log.ejs
+++ b/src/views/log.ejs
@@ -24,6 +24,7 @@
                 </ul>
             </ul>
         </li>
+
         <li class="list-group-item">
             <strong>29-02-2024: </strong>
             <ul>

--- a/src/views/log.ejs
+++ b/src/views/log.ejs
@@ -16,6 +16,15 @@
     <h1>Changelog!</h1>
     <ul class="list-group" id="my-list">
         <li class="list-group-item">
+            <strong>03-03-2024: </strong>
+            <ul>
+                Merged jduran7's pull request! Thank you!
+                <ul>
+                    <li>Added: Sort current games by game status.</li>
+                </ul>
+            </ul>
+        </li>
+        <li class="list-group-item">
             <strong>29-02-2024: </strong>
             <ul>
                 <li>Fixed: Bug where Assassin couldn't shoot someone if they logged in mid-game with a username of different casing.</li>


### PR DESCRIPTION
This change aims to resolve #588 by sorting the currentGames based on the following order (from 0-4, 0 being first and 4 being last):

`const gameStatusOrder = { 'Waiting': 0, 'Game in progress': 1, 'Paused': 2, 'Frozen': 3, 'Finished': 4 };`

The edge case of a new status that is not included in the `gameStatusOrder` is handled by having a fallback value which will evaluate as the number of items in `gameStatusOrder` and therefore push that new status to the end of the current games table.