### PR TITLE
fix: chat highlight of in-game chat after anonymized game completion

### DIFF
--- a/assets/scripts/lobby.js
+++ b/assets/scripts/lobby.js
@@ -278,7 +278,9 @@ function activateAvatarButtons() {
 
       const username =
         this.parentElement.parentElement.getAttribute('usernameofplayer');
-      const chatItems = $(`.room-chat-list li span[username='${username}']`);
+      const anonUsername =
+        this.parentElement.parentElement.getAttribute('anonusernameofplayer');
+      const chatItems = $(`.room-chat-list li span[username='${username}']${anonUsername ? `, .room-chat-list li span[username='${anonUsername}']` : ''}`);
 
       let playerHighlightColour = docCookies.getItem(
         `player${getIndexFromUsername(username)}HighlightColour`
@@ -1083,7 +1085,7 @@ function strOfAvatar(playerData, alliance) {
     colourToHighlightChatButton = '';
   }
 
-  let str = `<div usernameofplayer='${playerData.username}' class='playerDiv ${selectedAvatar}''>`;
+  let str = `<div usernameofplayer='${playerData.username}' ${playerData.anonUsername ? `anonusernameofplayer=${playerData.anonUsername}` : ''} class='playerDiv ${selectedAvatar}''>`;
 
   str += "<span class='avatarOptionButtons'>";
   str +=

--- a/src/gameplay/anonymizer.ts
+++ b/src/gameplay/anonymizer.ts
@@ -47,7 +47,7 @@ export class Anonymizer implements IRecoverable {
     this.gameFinished = true;
   }
 
-  anon(username: string): string {
+  anon(username: string, revealIfFinished = true): string {
     if (
       !this.initialised ||
       !this.anonymize ||
@@ -56,7 +56,7 @@ export class Anonymizer implements IRecoverable {
       return username;
     }
 
-    if (this.gameFinished) {
+    if (this.gameFinished && revealIfFinished) {
       return this.usernameAnonReveal(username);
     }
 

--- a/src/gameplay/game.ts
+++ b/src/gameplay/game.ts
@@ -18,6 +18,7 @@ import {
   IRecoverable,
   RecoverableComponent,
   RecoverEntry,
+  RoomPlayer,
 } from './types';
 import { GameTimer, Timeouts } from './gameTimer';
 import { VoidGameTracker } from './voidGameTracker';
@@ -960,7 +961,7 @@ class Game extends Room {
     this.pickNum++;
   }
 
-  getRoomPlayers() {
+  getRoomPlayers(): RoomPlayer[] {
     if (this.gameStarted === true) {
       const roomPlayers = [];
 
@@ -971,6 +972,11 @@ class Game extends Room {
 
         roomPlayers[i] = {
           username: this.anonymizer.anon(this.playersInGame[i].username),
+          anonUsername: this.anonymizer.anon(
+            this.playersInGame[i].username,
+            false,
+          ),
+
           avatarImgRes: this.anonymousMode
             ? null
             : this.playersInGame[i].request.user.avatarImgRes,

--- a/src/gameplay/room.ts
+++ b/src/gameplay/room.ts
@@ -10,6 +10,7 @@ import { avalonPhases, commonPhases } from './phases/phases';
 import { Role } from './roles/types';
 import { Phase } from './phases/types';
 import { millisToStr } from '../util/time';
+import { RoomPlayer } from './types';
 
 export class RoomConfig {
   host: string;
@@ -377,7 +378,7 @@ class Room {
     }
   }
 
-  getRoomPlayers() {
+  getRoomPlayers(): RoomPlayer[] {
     const roomPlayers = [];
 
     for (let i = 0; i < this.socketsOfPlayers.length; i++) {

--- a/src/gameplay/tests/anonymizer.test.ts
+++ b/src/gameplay/tests/anonymizer.test.ts
@@ -59,6 +59,24 @@ describe('Anonymizer', () => {
     }
   });
 
+  it('Returns the unrevealed username after game end if requested', () => {
+    // We also send the unrevealed username to the frontend after the game ends so that anonymized chat highlighting still works
+    anonymizer.initialise(baseUsernames, true);
+    const anonymizedUsernames = anonymizer.anonMany(baseUsernames);
+
+    anonymizer.setGameFinished();
+
+    const postGameFinishAnonymizedUsernames = baseUsernames.map((username) => {
+      return anonymizer.anon(username, false);
+    });
+
+    for (let i = 0; i < baseUsernames.length; i++) {
+      expect(postGameFinishAnonymizedUsernames[i]).toEqual(
+        anonymizedUsernames[i],
+      );
+    }
+  });
+
   it('Can recover', () => {
     anonymizer.initialise(baseUsernames, true);
     const anonymizedUsernames = anonymizer.anonMany(baseUsernames);

--- a/src/gameplay/types.ts
+++ b/src/gameplay/types.ts
@@ -24,7 +24,7 @@ export enum Alliance {
 }
 
 export interface RoleConstructor {
-  // @ts-ignore
+  // @ts-expect-error Cannot find name 'Role'.
   new (room: Game): Role;
 }
 
@@ -71,3 +71,12 @@ export interface IUser {
   lastIPAddress?: string;
   matchmakingBlacklist?: string[];
 }
+
+export type RoomPlayer = {
+  username: string;
+  anonUsername?: string;
+  avatarImgRes: string;
+  avatarImgSpy: string;
+  avatarHide: boolean;
+  claim: boolean;
+};


### PR DESCRIPTION
I played an anon game earlier today and noticed that highlighting of anonymized chat stopped working after the game had finished. This PR extends highlighting functionality so that the anonymized chat during the game can continue to be highlighted after identities are revealed.

Tested it in local environment.