### PR TITLE
Adding tourney related checks

### DIFF
--- a/src/routes/profile/index.tsx
+++ b/src/routes/profile/index.tsx
@@ -28,6 +28,7 @@ import { getAvatarLibrarySizeForUser } from '../../rewards/getRewards';
 
 const MAX_ACTIVE_AVATAR_REQUESTS = 1;
 const MIN_GAMES_REQUIRED = 100;
+const MIN_GAMES_REQUIRED_FOR_TOURNEY = 20;
 const VALID_DIMENSIONS = [128, 1024];
 const VALID_DIMENSIONS_STR = '128x128px or 1024x1024px';
 const MAX_FILESIZE = 1048576; // 1MB
@@ -582,10 +583,13 @@ async function validateUploadAvatarRequest(
   );
 
   // Check: Min game count satisfied. If user is a paid Patron, they can bypass this check
-  if (!patreonRewards && user.totalGamesPlayed < MIN_GAMES_REQUIRED) {
+  if (
+    !patreonRewards &&
+    user.totalGamesPlayed < MIN_GAMES_REQUIRED_FOR_TOURNEY
+  ) {
     return {
       valid: false,
-      errMsg: `You must play at least 100 games to submit a custom avatar request. You have played ${user.totalGamesPlayed} games.`,
+      errMsg: `You must play at least ${MIN_GAMES_REQUIRED_FOR_TOURNEY} game(s) to submit a custom avatar request. You have played ${user.totalGamesPlayed} games.`,
     };
   }
 

--- a/src/routes/profile/index.tsx
+++ b/src/routes/profile/index.tsx
@@ -5,6 +5,7 @@ import { renderToString } from 'react-dom/server';
 import imageSize from 'image-size';
 import multer from 'multer';
 import sanitizeHtml from 'sanitize-html';
+import assert from 'assert';
 
 import avatarRoutes from './avatarRoutes';
 import { checkProfileOwnership, isModMiddleware } from '../middleware';
@@ -28,7 +29,7 @@ import { getAvatarLibrarySizeForUser } from '../../rewards/getRewards';
 
 const MAX_ACTIVE_AVATAR_REQUESTS = 1;
 const MIN_GAMES_REQUIRED = 100;
-const MIN_GAMES_REQUIRED_FOR_TOURNEY = 20; // This should be less than MIN_GAMES_REQUIRED
+const MIN_GAMES_REQUIRED_FOR_TOURNEY = 25;
 const VALID_DIMENSIONS = [128, 1024];
 const VALID_DIMENSIONS_STR = '128x128px or 1024x1024px';
 const MAX_FILESIZE = 1048576; // 1MB
@@ -57,6 +58,11 @@ const sanitizeHtmlAllowedAttributesForumThread = {
   span: ['style'],
   b: ['style'],
 };
+
+assert(
+  MIN_GAMES_REQUIRED_FOR_TOURNEY <= MIN_GAMES_REQUIRED,
+  `Min games configured incorrectly.`,
+);
 
 const router = express.Router();
 router.use(avatarRoutes);

--- a/src/routes/profile/index.tsx
+++ b/src/routes/profile/index.tsx
@@ -28,7 +28,7 @@ import { getAvatarLibrarySizeForUser } from '../../rewards/getRewards';
 
 const MAX_ACTIVE_AVATAR_REQUESTS = 1;
 const MIN_GAMES_REQUIRED = 100;
-const MIN_GAMES_REQUIRED_FOR_TOURNEY = 20;
+const MIN_GAMES_REQUIRED_FOR_TOURNEY = 20; // This should be less than MIN_GAMES_REQUIRED
 const VALID_DIMENSIONS = [128, 1024];
 const VALID_DIMENSIONS_STR = '128x128px or 1024x1024px';
 const MAX_FILESIZE = 1048576; // 1MB
@@ -389,6 +389,9 @@ router.get(
 
     res.render('profile/customavatar', {
       username: req.user.username,
+      totalGamesPlayed: req.user.totalGamesPlayed,
+      MIN_GAMES_REQUIRED,
+      MIN_GAMES_REQUIRED_FOR_TOURNEY,
       MAX_FILESIZE_STR,
       VALID_DIMENSIONS,
       VALID_DIMENSIONS_STR,

--- a/src/routes/profile/index.tsx
+++ b/src/routes/profile/index.tsx
@@ -79,6 +79,7 @@ router.get('/mod/customavatar', isModMiddleware, async (req, res) => {
     resLink: string;
     spyLink: string;
     lastApprovedAvatarDate: Date | null;
+    totalGamesPlayed: number;
     enoughTimeElapsed: boolean;
     hasLibrarySpace: boolean;
     overallValid: boolean;
@@ -106,6 +107,7 @@ router.get('/mod/customavatar', isModMiddleware, async (req, res) => {
           lastApprovedAvatarDate: user.lastApprovedAvatarDate
             ? user.lastApprovedAvatarDate
             : null,
+          totalGamesPlayed: user.totalGamesPlayed,
           enoughTimeElapsed,
           hasLibrarySpace,
           overallValid,
@@ -118,6 +120,7 @@ router.get('/mod/customavatar', isModMiddleware, async (req, res) => {
     MAX_FILESIZE_STR,
     VALID_DIMENSIONS_STR,
     MIN_TIME_SINCE_LAST_AVATAR_APPROVAL_STR,
+    MIN_GAMES_REQUIRED,
     avatarLookupReact,
   });
 });

--- a/src/views/mod/customavatar.ejs
+++ b/src/views/mod/customavatar.ejs
@@ -88,6 +88,11 @@
                                 <span class="lastApprovedAvatarDate" data-date="<%= avreq.lastApprovedAvatarDate %>"></span>
                             </p>
 
+                            <%= avreq.totalGamesPlayed >= MIN_GAMES_REQUIRED ?
+                                    `✅ Total game(s) played: ${avreq.totalGamesPlayed}.` :
+                                    `❌ Total game(s) played: ${avreq.totalGamesPlayed}. Only tourney avatars may be approved in this case.` %>
+                            <br />
+
                             <%= avreq.hasLibrarySpace ?
                                     `✅ User avatar library is not full.` :
                                     `❌ User avatar library is full. Please check the user's avatar library before and after approval.` %>

--- a/src/views/profile/customavatar.ejs
+++ b/src/views/profile/customavatar.ejs
@@ -140,6 +140,31 @@ $(document).ready(() => {
             return;
         }
 
+        const MIN_GAMES_REQUIRED = <%= MIN_GAMES_REQUIRED %>;
+        const MIN_GAMES_REQUIRED_FOR_TOURNEY = <%= MIN_GAMES_REQUIRED_FOR_TOURNEY %>;
+        const totalGamesPlayed = <%= totalGamesPlayed %>;
+
+        if (totalGamesPlayed < MIN_GAMES_REQUIRED_FOR_TOURNEY) {
+            Swal.fire({
+                title: `You must play at least ${MIN_GAMES_REQUIRED_FOR_TOURNEY} game(s) to submit a custom avatar request.`,
+                type: "error"
+            });
+            return;
+        }
+
+        if (totalGamesPlayed < MIN_GAMES_REQUIRED) {
+            const swal = await Swal.fire({
+                title: `You must play at least ${MIN_GAMES_REQUIRED} game(s) to submit a custom avatar request apart from tourney avatars.`,
+                type: "error",
+                showCancelButton: true,
+                confirmButtonText: "Submit tourney avatar"
+            });
+
+            if (!swal.value) {
+                return;
+            }
+        }
+
         // Server side
         const formElement = document.querySelector('#customAvatarSubmissionForm');
         const bodyFormData = new FormData(formElement);


### PR DESCRIPTION
Removing automated 100 game check to submit avatars.
Replacing with 20 min cap for tourney use cases. Adding client side feedback that this path is only for tourney avatars
Adding manual checklist for mods to check total games played instead

![image](https://github.com/vck3000/ProAvalon/assets/118262634/2714cfb0-adcf-4596-bc11-d71f1c466c24)
