### PR TITLE
Identify timestamps with seconds as part of a quote

### DIFF
--- a/src/sockets/quote.ts
+++ b/src/sockets/quote.ts
@@ -71,7 +71,7 @@ export class Quote {
     // Get the Message
 
     // Take out timestamp
-    const splittedChatLines = chat.split(/\[\d\d:\d\d\]\s/);
+    const splittedChatLines = chat.split(/\[\d\d:\d\d(?::\d\d)?\]\s/);
 
     // First element must be empty string because timestamp must be first.
     if (splittedChatLines[0] !== '') {


### PR DESCRIPTION
Changes the regex for identifying timestamps to add an optional non-capturing group for seconds so that timestamps like "[00:00:00]" are identified correctly.