### PR TITLE
QoL UI-Moregano/Melron/Percival

### DIFF
--- a/assets/scripts/lobby.js
+++ b/assets/scripts/lobby.js
@@ -1004,8 +1004,9 @@ function strOfAvatar(playerData, alliance) {
     role = `<p class='role-p' style='width: ${roleWid}px; margin: auto;'>${gameData.see.roles[getIndexFromUsername(playerData.username)]
       }</p>`;
   } else if (gameStarted === true && gameData !== undefined) {
-    // if rendering our own player, give it the role tag
-    if (playerData.username === gameData.username) {
+     //if rendering our own player, give it the role tag
+     //if he is vanilla resistance or vanilla spy
+    if (playerData.username === gameData.username && gameData.role === gameData.alliance) {
       var roleWid = ctx.measureText(gameData.role).width + 20;
       role = `<p class='role-p' style='width: ${roleWid}px; margin: auto;'>${gameData.role}</p>`;
     } else if (gameData.see && gameData.see.roleTags) {

--- a/src/gameplay/gameEngine/game.ts
+++ b/src/gameplay/gameEngine/game.ts
@@ -2078,8 +2078,9 @@ class Game extends Room {
 
   private announceIllusionsIfAny() {
     // Melron
+    if(this.resRoles.includes(Role.Melron)) {
     const melronRole = this.specialRoles[Role.Melron];
-    if (melronRole) {
+    if (melronRole) { //TODO: is this if required now?
       const data = melronRole.getPublicGameData();
       if (data.spiesMelronSaw) {
         this.sendText(
@@ -2088,10 +2089,12 @@ class Game extends Room {
         );
       }
     }
+  }
 
     // Moregano
+  if(this.resRoles.includes(Role.Moregano)) {
     const moreganoRole = this.specialRoles[Role.Moregano];
-    if (moreganoRole) {
+    if (moreganoRole) { //TODO: is this if required now?
       const data = moreganoRole.getPublicGameData();
       if (data.spiesMoreganoSaw)
       {
@@ -2101,6 +2104,7 @@ class Game extends Room {
         );
       }
     }
+  }
   }
 
   private usernameIsPlayer(username: string) {

--- a/src/gameplay/gameEngine/roles/avalon/assassin.ts
+++ b/src/gameplay/gameEngine/roles/avalon/assassin.ts
@@ -32,6 +32,12 @@ class Assassin implements IRole {
       const spies = [];
 
       for (let i = 0; i < this.room.playersInGame.length; i++) {
+        if(this.room.playersInGame[i].role === this.role) {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role; 
+      
+      }
         if (this.room.playersInGame[i].alliance === Alliance.Spy) {
           if (this.room.playersInGame[i].role === Role.Oberon) {
             // don't add oberon

--- a/src/gameplay/gameEngine/roles/avalon/hitberon.ts
+++ b/src/gameplay/gameEngine/roles/avalon/hitberon.ts
@@ -22,19 +22,24 @@ class Hitberon implements IRole {
   see(): See {
     if (this.room.gameStarted === true) {
       const spies = [];
-
+      const roleTags: Record<string, string> = {}
+      
       for (let i = 0; i < this.room.playersInGame.length; i++) {
         if (this.room.playersInGame[i].role === Role.Hitberon) {
           spies.push(
             this.room.anonymizer.anon(this.room.playersInGame[i].username),
           );
+          roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role;
           break;
         }
       }
 
+
       return { spies, roleTags: {} };
+      }
     }
-  }
 
   checkSpecialMove() {}
 

--- a/src/gameplay/gameEngine/roles/avalon/isolde.ts
+++ b/src/gameplay/gameEngine/roles/avalon/isolde.ts
@@ -20,6 +20,11 @@ class Isolde implements IRole {
     const roleTags: Record<string, string> = {};
 
     for (let i = 0; i < this.room.playersInGame.length; i++) {
+       if(this.room.playersInGame[i].role === this.role) {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role; 
+      }
       if (this.room.playersInGame[i].role === Role.Tristan) {
         roleTags[
           this.room.anonymizer.anon(this.room.playersInGame[i].username)

--- a/src/gameplay/gameEngine/roles/avalon/melron.ts
+++ b/src/gameplay/gameEngine/roles/avalon/melron.ts
@@ -30,18 +30,27 @@ class Melron implements IRole {
   private spiesThatMelronSees?: string[];
 
   see(): See {
+      const roleTags: Record<string, string> = {};
     if (!this.room.gameStarted) {
       return { spies: [], roleTags: {} };
     }
 
+    for (let i = 0; i < this.room.playersInGame.length; i++) {
+        if(this.room.playersInGame[i].role === this.role) {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = "Merlin?";
+      }
+    }
     if (!this.spiesThatMelronSees) {
       this.initialiseMelronView();
     }
 
     return {
       spies: this.spiesThatMelronSees.map((u) => this.room.anonymizer.anon(u)),
-      roleTags: {},
+      roleTags
     };
+
   }
 
   private initialiseMelronView(): void {

--- a/src/gameplay/gameEngine/roles/avalon/merlin.ts
+++ b/src/gameplay/gameEngine/roles/avalon/merlin.ts
@@ -20,10 +20,27 @@ class Merlin implements IRole {
   }
 
   see(): See {
+          const roleTags: Record<string, string> = {};
+
     if (this.room.gameStarted === true) {
       const spies = [];
 
+      let melronExists: Boolean = false;
+      for (let i = 0; i < this.room.playersInGame.length; i++)
+      {
+        if(this.room.playersInGame[i].role === Role.Melron){
+            melronExists = true;
+          break;
+        }
+        else continue;
+      }
+
       for (let i = 0; i < this.room.playersInGame.length; i++) {
+        if(this.room.playersInGame[i].role === this.role) {     
+        roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = melronExists ? "Merlin?" : this.role;
+      }
         if (this.room.playersInGame[i].alliance === Alliance.Spy) {
           if (
             this.room.playersInGame[i].role === Role.Mordred ||
@@ -38,7 +55,7 @@ class Merlin implements IRole {
         }
       }
 
-      return { spies, roleTags: {} };
+      return { spies, roleTags };
     }
   }
 

--- a/src/gameplay/gameEngine/roles/avalon/mordred.ts
+++ b/src/gameplay/gameEngine/roles/avalon/mordred.ts
@@ -26,6 +26,11 @@ class Mordred implements IRole {
       const spies = [];
 
       for (let i = 0; i < this.room.playersInGame.length; i++) {
+        if(this.room.playersInGame[i].role === this.role) {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role;
+      }
         if (this.room.playersInGame[i].alliance === Alliance.Spy) {
           if (this.room.playersInGame[i].role === Role.Oberon) {
             // don't add oberon

--- a/src/gameplay/gameEngine/roles/avalon/moregano.ts
+++ b/src/gameplay/gameEngine/roles/avalon/moregano.ts
@@ -30,10 +30,19 @@ class Moregano implements IRole {
   private spiesThatMoreganoSees?: string[]; // includes self username as first element
 
   see(): See {
+          const roleTags: Record<string, string> = {};
+
     if (!this.room.gameStarted) {
       return { spies: [], roleTags: {} };
     }
 
+    for (let i = 0; i < this.room.playersInGame.length; i++) {
+        if(this.room.playersInGame[i].role === this.role) {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = "Morgana?";
+      }
+    }
     if (!this.spiesThatMoreganoSees) {
       this.initialiseMoreganoView();
     }
@@ -42,7 +51,7 @@ class Moregano implements IRole {
       spies: this.spiesThatMoreganoSees.map((u) =>
         this.room.anonymizer.anon(u),
       ),
-      roleTags: {},
+      roleTags
     };
   }
 

--- a/src/gameplay/gameEngine/roles/avalon/morgana.ts
+++ b/src/gameplay/gameEngine/roles/avalon/morgana.ts
@@ -21,11 +21,27 @@ class Morgana implements IRole {
   // Morgana sees all spies except oberon
   see(): See {
   const roleTags: Record<string, string> = {};
-  
+
     if (this.room.gameStarted === true) {
       const spies = [];
 
+      let moreganoExists: Boolean = false;
+      for (let i = 0; i < this.room.playersInGame.length; i++)
+      {
+        if(this.room.playersInGame[i].role === Role.Moregano){
+          moreganoExists = true;
+          break;
+        }
+        else continue;
+      }
+
       for (let i = 0; i < this.room.playersInGame.length; i++) {
+             if(this.room.playersInGame[i].role === this.role) 
+              {
+                  roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = moreganoExists ? "Morgana?" : this.role;
+      }
         if (this.room.playersInGame[i].alliance === Alliance.Spy) {
           if (this.room.playersInGame[i].role === Role.Oberon) {
             // don't add oberon
@@ -39,6 +55,8 @@ class Morgana implements IRole {
                 this.room.anonymizer.anon(this.room.playersInGame[i].username)
               ] = 'Hitberon';
             }
+       
+            
           }
         }
       }

--- a/src/gameplay/gameEngine/roles/avalon/oberon.ts
+++ b/src/gameplay/gameEngine/roles/avalon/oberon.ts
@@ -22,17 +22,22 @@ class Oberon implements IRole {
   see(): See {
     if (this.room.gameStarted === true) {
       const spies = [];
-
+      const roleTags: Record<string, string> = {}
+      
       for (let i = 0; i < this.room.playersInGame.length; i++) {
         if (this.room.playersInGame[i].role === Role.Oberon) {
           spies.push(
             this.room.anonymizer.anon(this.room.playersInGame[i].username),
           );
+          roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role;
           break;
         }
       }
 
-      return { spies, roleTags: {} };
+
+      return { spies, roleTags};
     }
   }
 

--- a/src/gameplay/gameEngine/roles/avalon/percival.ts
+++ b/src/gameplay/gameEngine/roles/avalon/percival.ts
@@ -21,15 +21,31 @@ class Percival implements IRole {
   // Percival sees Merlin and Morgana
   see(): See {
     const roleTags: Record<string, string> = {};
-
+    let merlinsCount = 0;
     for (let i = 0; i < this.room.playersInGame.length; i++) {
+      if (
+        this.room.playersInGame[i].role === Role.Merlin ||
+        this.room.playersInGame[i].role === Role.Morgana 
+      )
+      merlinsCount++;
+    }
+    for (let i = 0; i < this.room.playersInGame.length; i++) {
+      
       if (
         this.room.playersInGame[i].role === Role.Merlin ||
         this.room.playersInGame[i].role === Role.Morgana
       ) {
         roleTags[
           this.room.anonymizer.anon(this.room.playersInGame[i].username)
-        ] = 'Merlin?';
+        ] = (merlinsCount > 1 ? "Merlin?" : this.room.playersInGame[i].role);
+      }
+      if(
+        this.room.playersInGame[i].role === this.role
+      )
+      {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role; 
       }
     }
 

--- a/src/gameplay/gameEngine/roles/avalon/tristan.ts
+++ b/src/gameplay/gameEngine/roles/avalon/tristan.ts
@@ -21,6 +21,11 @@ class Tristan implements IRole {
     const roleTags: Record<string, string> = {};
 
     for (let i = 0; i < this.room.playersInGame.length; i++) {
+      if(this.room.playersInGame[i].role === this.role) {
+       roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = this.role; 
+      }
       if (this.room.playersInGame[i].role === Role.Isolde) {
         roleTags[
           this.room.anonymizer.anon(this.room.playersInGame[i].username)


### PR DESCRIPTION
- Percival, Morgana, and Merlin now only see question marks if deceptive roles (Morgana,Melron,Moregano) are in play
- Refactor role visibility logic for self-visibility
- Post-game announcements for spiesMelronSaw and spiesMoreganoSaw now only triggered if respective roles are in play