### PR TITLE
Moregano Hitberon UI fix

### DIFF
--- a/src/gameplay/gameEngine/roles/avalon/moregano.ts
+++ b/src/gameplay/gameEngine/roles/avalon/moregano.ts
@@ -28,8 +28,12 @@ class Moregano implements IRole {
   }
 
   private spiesThatMoreganoSees?: string[]; // includes self username as first element
+  private hitberonThatMoreganoSees?: string; // incase hitberon is in play
+  private hitberonExists: boolean = false;
 
   see(): See {
+  const roleTags: Record<string, string> = {};
+
     if (!this.room.gameStarted) {
       return { spies: [], roleTags: {} };
     }
@@ -38,11 +42,16 @@ class Moregano implements IRole {
       this.initialiseMoreganoView();
     }
 
+    if(this.hitberonExists) {
+      console.log(this.room.anonymizer.anon(this.hitberonThatMoreganoSees));
+      roleTags[this.room.anonymizer.anon(this.hitberonThatMoreganoSees)] = "Hitberon";
+    }
+
     return {
       spies: this.spiesThatMoreganoSees.map((u) =>
         this.room.anonymizer.anon(u),
       ),
-      roleTags: {},
+      roleTags
     };
   }
 
@@ -53,6 +62,10 @@ class Moregano implements IRole {
       if (p.alliance === Alliance.Spy) {
         if (p.role === Role.Oberon) {
           continue;
+        }
+        if(p.role === Role.Hitberon) {
+          this.hitberonExists = true;
+          console.log("hitberon exists!");
         }
 
         visibleSpyCount++;
@@ -80,7 +93,14 @@ class Moregano implements IRole {
     const selfUsername = selfPlayer.username;
 
     const picks = pool.slice(0, othersNeeded);
-
+    
+    if(this.hitberonExists) {
+      this.hitberonThatMoreganoSees = picks[0];
+      console.log(this.hitberonThatMoreganoSees);
+      shuffleArray(picks);
+      //need to shuffle again to protect against
+      // 2nd name in array always being hitberon.
+    }
     // Cache REAL usernames (self first)
     this.spiesThatMoreganoSees = [selfUsername, ...picks];
   }

--- a/src/gameplay/gameEngine/roles/avalon/moregano.ts
+++ b/src/gameplay/gameEngine/roles/avalon/moregano.ts
@@ -43,8 +43,7 @@ class Moregano implements IRole {
     }
 
     if(this.hitberonExists) {
-      console.log(this.room.anonymizer.anon(this.hitberonThatMoreganoSees));
-      roleTags[this.room.anonymizer.anon(this.hitberonThatMoreganoSees)] = "Hitberon";
+      roleTags[this.room.anonymizer.anon(this.hitberonThatMoreganoSees)] = 'Hitberon';
     }
 
     return {
@@ -65,7 +64,6 @@ class Moregano implements IRole {
         }
         if(p.role === Role.Hitberon) {
           this.hitberonExists = true;
-          console.log("hitberon exists!");
         }
 
         visibleSpyCount++;
@@ -96,10 +94,9 @@ class Moregano implements IRole {
     
     if(this.hitberonExists) {
       this.hitberonThatMoreganoSees = picks[0];
-      console.log(this.hitberonThatMoreganoSees);
       shuffleArray(picks);
-      //need to shuffle again to protect against
-      // 2nd name in array always being hitberon.
+      // need to shuffle again to protect against
+      // 2nd name in spiesThatMoreganoSees always being hitberon.
     }
     // Cache REAL usernames (self first)
     this.spiesThatMoreganoSees = [selfUsername, ...picks];


### PR DESCRIPTION
If Hitberon is in-game, Moregano should see a fellow dummy-spy as "Hitberon" to match the real Morgana's view.
Given how minor a bug fix this is, I'm not sure if it's worth storing in the gameRecords database/or even announcing at the end of the game. Let me know if it is required.