### PR TITLE
Redesign role/card selection UI and add Galahad role

### DIFF
--- a/assets/scripts/lobby.js
+++ b/assets/scripts/lobby.js
@@ -1428,7 +1428,26 @@ function drawVoteHistory(data) {
   //  ProNub -> Bot2 -> Bot123 ->
 }
 
+function getNewOptions() {
+  const labels = $(
+    '#spyRolesButtonGroup label, #resRolesButtonGroup label, #cardsButtonGroup label'
+  );
+
+  const selectedRolesCards = [];
+  for (let i = 0; i < labels.length; i++) {
+    if (labels[i].classList.contains('active')) {
+      selectedRolesCards.push(labels[i].dataset.name);
+    }
+  }
+  return selectedRolesCards;
+}
+
 function getOptions() {
+  const newCards = getNewOptions();
+  if (newCards.length > 0) {
+    return newCards;
+  }
+
   // console.log($("#rolesCardsButtonGroup label"));
   const rolesCards = $('#rolesCardsButtonGroup label');
 

--- a/assets/scripts/lobby/sockets/sockets.js
+++ b/assets/scripts/lobby/sockets/sockets.js
@@ -709,7 +709,9 @@ const useNewButtonGroup = (gameModeObj) => {
     const betaLabel = roleObj.isBeta ? ' <span class="badge badge-warning badge-beta">beta</span>' : '';
     const active = defaultActiveRoles.includes(name) ? 'active' : '';
 
-    if (roleObj.alliance === 'Spy') {
+    if (skipRoles.includes(name)) {
+      // do nothing
+    } else if (roleObj.alliance === 'Spy') {
       spyStr += `<label class='btn btn-mine btn-mine-role btn-danger ${active}' data-name='${name}' data-trigger='hover' data-html='true' data-placement='right' title='${name}' data-content='${roleObj.description.replace(/'/g, '&#39;')}'>`;
       spyStr += `<input style='display: none;' name='${name.toLowerCase()}' id='${name.toLowerCase()}' type='checkbox' autocomplete='off' checked> ${name}${betaLabel}`;
       spyStr += '</label>';

--- a/assets/scripts/lobby/sockets/sockets.js
+++ b/assets/scripts/lobby/sockets/sockets.js
@@ -698,9 +698,58 @@ socket.on('gameModes', (GAME_MODE_NAMES) => {
 const defaultActiveRoles = ['Merlin', 'Assassin', 'Percival', 'Morgana'];
 const skipRoles = ['Resistance', 'Spy'];
 
-socket.on('update-game-modes-in-room', (gameModeObj) => {
-  let str = '';
+const useNewButtonGroup = (gameModeObj) => {
+  let spyStr = '';
+  let resStr = '';
+  let cardStr = '';
 
+  // Roles
+  gameModeObj.rolesArray.forEach((roleObj) => {
+    const name = roleObj.role;
+    const betaLabel = roleObj.isBeta ? ' <span class="badge badge-warning badge-beta">beta</span>' : '';
+    const active = defaultActiveRoles.includes(name) ? 'active' : '';
+
+    if (roleObj.alliance === 'Spy') {
+      spyStr += `<label class='btn btn-mine btn-mine-role btn-danger ${active}' data-name='${name}' data-trigger='hover' data-html='true' data-placement='right' title='${name}' data-content='${roleObj.description.replace(/'/g, '&#39;')}'>`;
+      spyStr += `<input style='display: none;' name='${name.toLowerCase()}' id='${name.toLowerCase()}' type='checkbox' autocomplete='off' checked> ${name}${betaLabel}`;
+      spyStr += '</label>';
+    } else {
+      resStr += `<label class='btn btn-mine btn-mine-role btn-success ${active}' data-name='${name}' data-trigger='hover' data-html='true' data-placement='right' title='${name}' data-content='${roleObj.description.replace(/'/g, '&#39;')}'>`;
+      resStr += `<input style='display: none;' name='${name.toLowerCase()}' id='${name.toLowerCase()}' type='checkbox' autocomplete='off' checked> ${name}${betaLabel}`;
+      resStr += '</label>';
+    }
+  });
+
+  // Cards
+  gameModeObj.cardsArray.forEach((cardObj) => {
+    const name = cardObj.card;
+    const betaLabel = cardObj.isBeta ? ' <span class="badge badge-info badge-beta">beta</span>' : '';
+    cardStr += `<label class='btn btn-mine btn-mine-role btn-info' data-name='${name}' data-trigger='hover' data-html='true' data-placement='right' title='${name}' data-content='${cardObj.description.replace(/'/g, '&#39;')}'>`;
+    cardStr += `<input style='display: none;' name='${name.toLowerCase()}' id='${name.toLowerCase()}' type='checkbox' autocomplete='off' checked> ${name}${betaLabel}`;
+    cardStr += '</label>';
+  });
+
+  // Set it in
+  $('#spyLabel')[0].innerHTML = 'Spies';
+  $('#resLabel')[0].innerHTML = 'Resistance';
+  $('#cardLabel')[0].innerHTML = 'Cards';
+  $('#spyRolesButtonGroup')[0].innerHTML = spyStr;
+  $('#resRolesButtonGroup')[0].innerHTML = resStr;
+  $('#cardsButtonGroup')[0].innerHTML = cardStr;
+  $('#spyRolesButtonGroup [data-trigger="hover"]').popover();
+  $('#resRolesButtonGroup [data-trigger="hover"]').popover();
+  $('#cardsButtonGroup [data-trigger="hover"]').popover();
+}
+
+socket.on('update-game-modes-in-room', (gameModeObj) => {
+  // New button group
+  if (gameModeObj.rolesArray && gameModeObj.cardsArray) {
+    return useNewButtonGroup(gameModeObj);
+  }
+
+  // Old button group
+  let str = '';
+  let infoIconString = '';
   let count = 0;
 
   // Roles

--- a/assets/scripts/lobby/sockets/sockets.js
+++ b/assets/scripts/lobby/sockets/sockets.js
@@ -730,9 +730,9 @@ const useNewButtonGroup = (gameModeObj) => {
   });
 
   // Set it in
-  $('#spyLabel')[0].innerHTML = 'Spies';
-  $('#resLabel')[0].innerHTML = 'Resistance';
-  $('#cardLabel')[0].innerHTML = 'Cards';
+  $('#spyLabel')[0].innerHTML = 'Spies:';
+  $('#resLabel')[0].innerHTML = 'Resistance:';
+  $('#cardLabel')[0].innerHTML = 'Cards:';
   $('#spyRolesButtonGroup')[0].innerHTML = spyStr;
   $('#resRolesButtonGroup')[0].innerHTML = resStr;
   $('#cardsButtonGroup')[0].innerHTML = cardStr;

--- a/assets/stylesheets/dark.css
+++ b/assets/stylesheets/dark.css
@@ -103,11 +103,11 @@
 }
 
 .dark .btn-mine-role.btn-danger.active {
-  background-color: #b63b3b !important;
+  background-color: #923a3a !important;
 }
 
 .dark .btn-mine-role.btn-success.active {
-  background-color: #5ac06c !important;
+  background-color: #2e6437 !important;
 }
 
 .dark .btn-mine-role.btn-info.active {
@@ -122,34 +122,34 @@
 
 .dark .btn-mine:hover,
 .dark .btn-mine:focus {
-  background: #666;
-  border-color: #888;
+  background: #333;
+  border-color: white;
 }
 
 .dark .btn-mine-role.btn-danger,
 .dark .btn-mine-role.btn-success,
 .dark .btn-mine-role.btn-info {
-  color: white;
-  background-color: #444 !important;
-  border-color: #666 !important;
+  color: #9e9e9e;
+  background-color: #373737 !important;
+  border-color: black !important;
 }
 
 .dark .btn-mine-role.btn-danger:hover,
 .dark .btn-mine-role.btn-danger:focus {
-  background-color: #d38383 !important;
+  background-color: #a54f4f !important;
   border-color: rgb(179, 118, 118) !important;
 }
 
 .dark .btn-mine-role.btn-success:hover,
 .dark .btn-mine-role.btn-success:focus {
-  background-color: #86c091 !important;
+  background-color: #51885a !important;
   border-color: rgb(135, 208, 140) !important;
 }
 
 .dark .btn-mine-role.btn-info:hover,
 .dark .btn-mine-role.btn-info:focus {
-  background-color: #1f6a8e !important;
-  border-color: #39a !important;
+  background-color: rgb(95, 150, 177) !important;
+  border-color: rgb(118, 184, 196) !important;
 }
 
 .dark .popover {

--- a/assets/stylesheets/dark.css
+++ b/assets/stylesheets/dark.css
@@ -102,6 +102,77 @@
   background: black;
 }
 
+.dark .btn-mine-role.btn-danger.active {
+  background-color: #b63b3b !important;
+}
+
+.dark .btn-mine-role.btn-success.active {
+  background-color: #5ac06c !important;
+}
+
+.dark .btn-mine-role.btn-info.active {
+  background-color: #1f6a8e !important;
+}
+
+.dark .btn-mine {
+  color: white;
+  border: 1px solid #666;
+  background: #444;
+}
+
+.dark .btn-mine:hover,
+.dark .btn-mine:focus {
+  background: #666;
+  border-color: #888;
+}
+
+.dark .btn-mine-role.btn-danger,
+.dark .btn-mine-role.btn-success,
+.dark .btn-mine-role.btn-info {
+  color: white;
+  background-color: #444 !important;
+  border-color: #666 !important;
+}
+
+.dark .btn-mine-role.btn-danger:hover,
+.dark .btn-mine-role.btn-danger:focus {
+  background-color: #d38383 !important;
+  border-color: rgb(179, 118, 118) !important;
+}
+
+.dark .btn-mine-role.btn-success:hover,
+.dark .btn-mine-role.btn-success:focus {
+  background-color: #86c091 !important;
+  border-color: rgb(135, 208, 140) !important;
+}
+
+.dark .btn-mine-role.btn-info:hover,
+.dark .btn-mine-role.btn-info:focus {
+  background-color: #1f6a8e !important;
+  border-color: #39a !important;
+}
+
+.dark .popover {
+  background-color: #2a2a2a;
+  color: #ddd;
+  border-color: #ccc;
+}
+
+.dark .popover-title {
+  background-color: #333;
+  color: #eee;
+  border-bottom-color: #ccc;
+}
+
+.dark .popover.right > .arrow::after {
+  border-right-color: #2a2a2a;
+}
+
+.dark .popover.right > .arrow {
+  border-right-color: #ccc;
+}
+
+
 .dark .modal-content {
   background-color: #333;
 }

--- a/assets/stylesheets/lobby.css
+++ b/assets/stylesheets/lobby.css
@@ -588,6 +588,45 @@ well {
     background-color: #e5e5e5;
 }
 
+.btn-mine-role {
+    color: black;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    margin-bottom: 10px;
+}
+
+.btn-mine-role.active {
+    background-color: rgba(163, 244, 255, 0.6) !important;
+}
+
+.btn-mine-role.btn-danger.active {
+    background-color: #cd5c5c !important;
+}
+
+.btn-mine-role.btn-success.active {
+    background-color: #6fbd81 !important;
+}
+
+.btn-mine-role.btn-info.active {
+    background-color: #4ca2cd !important;
+}
+
+.popover {
+    min-width: 250px;
+}
+
+.badge-beta {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateX(40%);
+    background-color: transparent !important;
+    color: inherit !important;
+    border: 1px solid currentColor;
+}
+
 /* This is for the special text like lady, so users cannot select to copy paste */
 
 .noselect {

--- a/src/gameplay/gameEngine/roles/avalon/galahad.ts
+++ b/src/gameplay/gameEngine/roles/avalon/galahad.ts
@@ -1,0 +1,46 @@
+import { Alliance, See } from '../../types';
+import { IRole, Role } from '../types';
+import Game from '../../game';
+
+class Galahad implements IRole {
+  room: Game;
+
+  static role = Role.Galahad;
+  role = Role.Galahad;
+  alliance = Alliance.Resistance;
+
+  description = 'Knows the identity of Merlin and the Assassin.';
+  orderPriorityInOptions = 79;
+
+  specialPhase: string;
+
+  isBeta = true;
+
+  constructor(thisRoom: any) {
+    this.room = thisRoom;
+  }
+
+  // Galahad sees Merlin and Assassin
+  see(): See {
+    const roleTags: Record<string, string> = {};
+
+    for (let i = 0; i < this.room.playersInGame.length; i++) {
+      if (
+        this.room.playersInGame[i].role === Role.Merlin ||
+        this.room.playersInGame[i].role === Role.Assassin
+      ) {
+        roleTags[
+          this.room.anonymizer.anon(this.room.playersInGame[i].username)
+        ] = 'Merlin/Assassin?';
+      }
+    }
+
+    return { spies: [], roleTags };
+  }
+
+  checkSpecialMove(): void {}
+
+  getPublicGameData(): any {}
+}
+
+export default Galahad;

--- a/src/gameplay/gameEngine/roles/roles.ts
+++ b/src/gameplay/gameEngine/roles/roles.ts
@@ -15,6 +15,7 @@ import MordredAssassin from './avalon/mordredassassin';
 import Hitberon from './avalon/hitberon';
 import Melron from './avalon/melron';
 import Moregano from './avalon/moregano';
+import Galahad from './avalon/galahad';
 
 
 type Class<I, Args extends any[] = any[]> = new (...args: Args) => I;
@@ -38,11 +39,14 @@ export const avalonRoles: Record<string, Class<IRole>> = {
 
   [Melron.role]: Melron,
   [Moregano.role]: Moregano,
+
+  [Galahad.role]: Galahad,
 };
 
 export const rolesThatCantGuessMerlin = [
   Role.Merlin,
   Role.Percival,
+  Role.Galahad,
   Role.Assassin,
 ];
 

--- a/src/gameplay/gameEngine/roles/types.ts
+++ b/src/gameplay/gameEngine/roles/types.ts
@@ -21,6 +21,8 @@ export enum Role {
 
   Melron = 'Melron',
   Moregano = 'Moregano',
+
+  Galahad = 'Galahad',
 }
 
 export interface IRole {

--- a/src/gameplay/gameEngine/room.ts
+++ b/src/gameplay/gameEngine/room.ts
@@ -546,7 +546,34 @@ class Room {
     const cardDescriptions = [];
     const cardPriorities = [];
 
+    const rolesArray: {
+      role: Role;
+      description: string;
+      alliance: string;
+      orderPriorityInOptions: number;
+      isBeta: boolean;
+    }[] = [];
+
+    const cardsArray: {
+      card: string;
+      description: string;
+      orderPriorityInOptions: number;
+      isBeta: boolean;
+    }[] = [];
+
     const skipRoles = [Role.Resistance, Role.Spy];
+
+    const keys = Object.keys(this.specialRoles);
+    
+    for (let roleName of keys) {
+      rolesArray.push({
+        role: this.specialRoles[roleName].role,
+        description: this.specialRoles[roleName].description,
+        alliance: this.specialRoles[roleName].alliance,
+        orderPriorityInOptions: this.specialRoles[roleName].orderPriorityInOptions || 0,
+        isBeta: this.specialRoles[roleName].isBeta || false,
+      });
+    }
 
     for (let key in this.specialRoles) {
       if (this.specialRoles.hasOwnProperty(key) === true) {
@@ -575,6 +602,13 @@ class Room {
         } else {
           cardPriorities.push(this.specialCards[key].orderPriorityInOptions);
         }
+
+        cardsArray.push({
+          card: this.specialCards[key].card,
+          description: this.specialCards[key].description,
+          orderPriorityInOptions: this.specialCards[key].orderPriorityInOptions || 0,
+          isBeta: this.specialCards[key].isBeta || false,
+        });
       }
     }
 
@@ -592,6 +626,8 @@ class Room {
         descriptions: cardDescriptions,
         orderPriorities: cardPriorities,
       },
+      rolesArray,
+      cardsArray,
     };
 
     // Send the data to the socket.

--- a/src/gameplay/gameEngine/tests/game.test.ts
+++ b/src/gameplay/gameEngine/tests/game.test.ts
@@ -407,7 +407,7 @@ describe('Game Engine', () => {
       ]);
     });
 
-    it('Galahad sees Merlin and Assassin tagged as Merlin/Assassin?', () => {
+    it('sees Merlin and Assassin tagged as Merlin/Assassin?', () => {
       const galahad = game.specialRoles[Role.Galahad];
       const { roleTags } = galahad.see();
 
@@ -418,7 +418,7 @@ describe('Game Engine', () => {
       expect(roleTags[assassinUsername]).toEqual('Merlin/Assassin?');
     });
 
-    it('Galahad does not see spies other than Assassin', () => {
+    it('does not see spies other than Assassin', () => {
       const galahad = game.specialRoles[Role.Galahad];
       const { roleTags } = galahad.see();
 
@@ -427,13 +427,13 @@ describe('Game Engine', () => {
       expect(roleTags[morganaUsername]).toBeUndefined();
     });
 
-    it('Galahad does not see other resistance members', () => {
+    it('does not see other resistance members', () => {
       const galahad = game.specialRoles[Role.Galahad];
       const { roleTags } = galahad.see();
 
-      const percivalUsername = getUsernameOfRole(Role.Percival);
+      const resistanceUsername = getUsernameOfRole(Role.Resistance);
 
-      expect(roleTags[percivalUsername]).toBeUndefined();
+      expect(roleTags[resistanceUsername]).toBeUndefined();
     });
   });
 

--- a/src/gameplay/gameEngine/tests/game.test.ts
+++ b/src/gameplay/gameEngine/tests/game.test.ts
@@ -397,6 +397,46 @@ describe('Game Engine', () => {
     });
   });
 
+  describe('Galahad', () => {
+    beforeEach(() => {
+      startGame(6, [
+        Role.Merlin,
+        Role.Assassin,
+        Role.Morgana,
+        Role.Galahad,
+      ]);
+    });
+
+    it('Galahad sees Merlin and Assassin tagged as Merlin/Assassin?', () => {
+      const galahad = game.specialRoles[Role.Galahad];
+      const { roleTags } = galahad.see();
+
+      const merlinUsername = getUsernameOfRole(Role.Merlin);
+      const assassinUsername = getUsernameOfRole(Role.Assassin);
+
+      expect(roleTags[merlinUsername]).toEqual('Merlin/Assassin?');
+      expect(roleTags[assassinUsername]).toEqual('Merlin/Assassin?');
+    });
+
+    it('Galahad does not see spies other than Assassin', () => {
+      const galahad = game.specialRoles[Role.Galahad];
+      const { roleTags } = galahad.see();
+
+      const morganaUsername = getUsernameOfRole(Role.Morgana);
+
+      expect(roleTags[morganaUsername]).toBeUndefined();
+    });
+
+    it('Galahad does not see other resistance members', () => {
+      const galahad = game.specialRoles[Role.Galahad];
+      const { roleTags } = galahad.see();
+
+      const percivalUsername = getUsernameOfRole(Role.Percival);
+
+      expect(roleTags[percivalUsername]).toBeUndefined();
+    });
+  });
+
   describe('Check Options', () => {
     it('Allows fab 4', () => {
       const checkOptions = Game.checkOptions([

--- a/src/views/lobby.ejs
+++ b/src/views/lobby.ejs
@@ -974,7 +974,38 @@
         <br>
         <label>Anonymous mode:</label>
         <input type="checkbox" name="startGameOptionsAnonymousMode" id="startGameOptionsAnonymousMode"/>
+        <br />
+        <br />
 
+        <!-- new button group -->
+        <label id="spyLabel"></label>
+        <div class="row">
+          <div
+          class="btn-group-vertical col-sm-8 col-xs-12"
+          data-toggle="buttons"
+          id="spyRolesButtonGroup"
+          ></div>
+        </div>
+
+        <label id="resLabel"></label>
+        <div class="row">
+          <div
+            class="btn-group-vertical col-sm-8 col-xs-12"
+            data-toggle="buttons"
+            id="resRolesButtonGroup"
+          ></div>
+        </div>
+
+        <label id="cardLabel"></label>
+        <div class="row">
+          <div
+            class="btn-group-vertical col-sm-8 col-xs-12"
+            data-toggle="buttons"
+            id="cardsButtonGroup"
+          ></div>
+        </div>
+
+        <!-- old button group -->
         <div class="row">
           <div
             class="btn-group-vertical col-sm-4 col-xs-12"


### PR DESCRIPTION
Adds Galahad role
- Sees both Merlin and the Assassin tagged as Merlin/Assassin?

Some css changes:
- Splits the combined roles+cards button group into separate spy, resistance, and cards sections, with hover popovers showing role descriptions
- old button group remains as fallback for backwards compatibility

<img width="2549" height="1205" alt="Screenshot 2026-03-17 at 11 27 34 PM" src="https://github.com/user-attachments/assets/7eceb404-58c9-4abe-8834-51b0ced5c0bd" />

<img width="2550" height="1210" alt="Screenshot 2026-03-17 at 11 27 22 PM" src="https://github.com/user-attachments/assets/ed3c12af-6368-485b-af75-b1ba5c23f8c7" />
