### PR TITLE
Add /averifyuseremail admin command

### DIFF
--- a/src/sockets/commands/admin/averifyuseremail.ts
+++ b/src/sockets/commands/admin/averifyuseremail.ts
@@ -1,0 +1,43 @@
+import { sendReplyToCommand } from '../../sockets';
+import { SocketUser } from '../../types';
+import User from '../../../models/user';
+import { Command } from '../types';
+
+export const averifyuseremail: Command = {
+  command: 'averifyuseremail',
+  help: "/averifyuseremail <username>: set a user's emailVerified field to true",
+  run: async (args: string[], socket: SocketUser) => {
+    if (args.length < 2) {
+      sendReplyToCommand(socket, 'Specify a username.');
+      return;
+    }
+
+    const username = args[1];
+
+    const user = await User.findOne({
+      usernameLower: username.toLowerCase(),
+    });
+
+    if (!user) {
+      sendReplyToCommand(socket, `Could not find user ${username}.`);
+      return;
+    }
+
+    if (user.emailVerified) {
+      sendReplyToCommand(
+        socket,
+        `${user.username}'s email is already verified.`,
+      );
+      return;
+    }
+
+    user.emailVerified = true;
+    user.markModified('emailVerified');
+    await user.save();
+
+    sendReplyToCommand(
+      socket,
+      `${user.username}'s email has been marked as verified.`,
+    );
+  },
+};

--- a/src/sockets/commands/admin/index.ts
+++ b/src/sockets/commands/admin/index.ts
@@ -7,6 +7,7 @@ import { atestgame } from './atestgame';
 import { adiscordmessage } from './adiscordmessage';
 import { acreatetestaccounts } from './acreatetestaccounts';
 import { ausernametoemail } from './ausernametoemail';
+import { averifyuseremail } from './averifyuseremail';
 import { asessions } from './asessions';
 
 // Delete the below following season update. Purely for testing purposes
@@ -35,6 +36,7 @@ export const adminCommands: Commands = {
   [atestgame.command]: atestgame,
   [asessions.command]: asessions,
   [ausernametoemail.command]: ausernametoemail,
+  [averifyuseremail.command]: averifyuseremail,
   [atogglecreateroom.command]: atogglecreateroom,
   ...debugCommands,
 };


### PR DESCRIPTION
## Summary
- Adds a new admin command `/averifyuseremail <username>` that looks up a user and sets their `emailVerified` field to `true`.
- Follows the existing pattern used by `/ausernametoemail` for argument parsing and user lookup, and the `markModified('emailVerified')` + `save()` pattern already used in `acreatetestaccounts`.
- Registered in `src/sockets/commands/admin/index.ts`.

## Test plan
- [ ] Run as admin: `/averifyuseremail` (no args) → replies "Specify a username."
- [ ] Run with unknown username → replies "Could not find user <name>."
- [ ] Run on a user whose email is already verified → replies "<name>'s email is already verified." and DB state unchanged.
- [ ] Run on a user whose email is not verified → replies "<name>'s email has been marked as verified." and confirm `emailVerified === true` in the DB.
- [ ] Confirm the command shows up in admin help / is callable only for admins (existing dispatcher gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)