### PR TITLE
Fix sparse games list payload in update-current-games-list

### DIFF
--- a/src/sockets/sockets.ts
+++ b/src/sockets/sockets.ts
@@ -899,37 +899,30 @@ export const updateCurrentGamesList = function () {
   // prepare room data to send to players.
   const gamesList = [];
   for (let i = 0; i < rooms.length; i++) {
-    // If the game exists
-    if (rooms[i]) {
-      // create new array to send
-      gamesList[i] = {};
-      // get status of game
-      gamesList[i].status = rooms[i].getStatus();
-
-      if (rooms[i].joinPassword !== undefined) {
-        gamesList[i].passwordLocked = true;
-      } else {
-        gamesList[i].passwordLocked = false;
-      }
-      // get room ID
-      gamesList[i].roomId = rooms[i].roomId;
-      gamesList[i].gameMode =
-        rooms[i].gameMode.charAt(0).toUpperCase() + rooms[i].gameMode.slice(1);
-      gamesList[i].gameType = rooms[i].ranked ? 'Ranked' : 'Unranked';
-      // console.log("Room " + rooms[i].roomId + " has host: " + rooms[i].host);
-      gamesList[i].hostUsername = rooms[i].host;
-      if (rooms[i].gameStarted === true) {
-        gamesList[i].numOfPlayersInside = rooms[i].playersInGame.length;
-        gamesList[i].missionHistory = rooms[i].missionHistory;
-        gamesList[i].missionNum = rooms[i].missionNum;
-        gamesList[i].pickNum = rooms[i].pickNum;
-      } else {
-        gamesList[i].numOfPlayersInside = rooms[i].socketsOfPlayers.length;
-      }
-      gamesList[i].maxNumPlayers = rooms[i].maxNumPlayers;
-      gamesList[i].numOfSpectatorsInside =
-        rooms[i].allSockets.length - rooms[i].socketsOfPlayers.length;
+    if (!rooms[i]) {
+      continue;
     }
+    const game: any = {
+      status: rooms[i].getStatus(),
+      passwordLocked: rooms[i].joinPassword !== undefined,
+      roomId: rooms[i].roomId,
+      gameMode:
+        rooms[i].gameMode.charAt(0).toUpperCase() + rooms[i].gameMode.slice(1),
+      gameType: rooms[i].ranked ? 'Ranked' : 'Unranked',
+      hostUsername: rooms[i].host,
+      maxNumPlayers: rooms[i].maxNumPlayers,
+      numOfSpectatorsInside:
+        rooms[i].allSockets.length - rooms[i].socketsOfPlayers.length,
+    };
+    if (rooms[i].gameStarted === true) {
+      game.numOfPlayersInside = rooms[i].playersInGame.length;
+      game.missionHistory = rooms[i].missionHistory;
+      game.missionNum = rooms[i].missionNum;
+      game.pickNum = rooms[i].pickNum;
+    } else {
+      game.numOfPlayersInside = rooms[i].socketsOfPlayers.length;
+    }
+    gamesList.push(game);
   }
   allSockets.forEach((sock) => {
     sock.emit('update-current-games-list', gamesList);


### PR DESCRIPTION
## Summary
- `updateCurrentGamesList` assigned game objects by room index (`gamesList[i] = {...}`), so when rooms only existed at high IDs (e.g. 5 and 6), clients received `[null, null, null, null, {room5}, {room6}]`.
- Switched to `gamesList.push(game)` so the emitted array is compact.

The client handler already filters falsy entries and reads `roomId` off each game object (`assets/scripts/lobby/sockets/sockets.js`), so this is a drop-in fix with no client-side changes needed.

## Test plan
- [ ] Open the lobby with no custom games — confirm an empty list (no phantom rows).
- [ ] Create a game, leave it, create another — confirm only one row renders.
- [ ] Have multiple rooms exist where low room IDs are unused; confirm the lobby renders exactly those rooms with correct metadata.
- [ ] Join a room from the list and confirm it opens the correct `roomId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)