### PR TITLE
Fix Melron unmasking via /guessmerlin

### DIFF
--- a/src/gameplay/gameEngine/game.ts
+++ b/src/gameplay/gameEngine/game.ts
@@ -1946,15 +1946,20 @@ class Game extends Room {
       return 'No such user is playing at your table.';
     }
 
-    // Check the guesser isnt Merlin/Percy
+    // Check the guesser isnt Merlin/Percy.
+    // Use displayRole so deceptive roles (Melron) cannot unmask themselves
+    // by probing this command — Melron must behave like Merlin here.
     const guesserPlayer = this.playersInGame.find(
       (player) => player.username === guesserUsername,
     );
+    const effectiveGuesserRole = guesserPlayer?.displayRole
+      ? guesserPlayer.displayRole
+      : guesserPlayer?.role;
     if (
       guesserPlayer !== undefined &&
-      rolesThatCantGuessMerlin.indexOf(guesserPlayer.role) !== -1
+      rolesThatCantGuessMerlin.indexOf(effectiveGuesserRole) !== -1
     ) {
-      return `${guesserPlayer.role} cannot submit a guess.`;
+      return `${effectiveGuesserRole} cannot submit a guess.`;
     }
 
     // Accept the guess

--- a/src/views/changelog.ejs
+++ b/src/views/changelog.ejs
@@ -19,6 +19,7 @@
             <strong>10-05-2026: </strong>
             <ul>
                 <li>Fixed: Melron and Moregano spy lists were being included in the gameplay payload sent to all players and spectators during the game, instead of only after the game ended.</li>
+                <li>Fixed: Melron could unmask themselves by trying /guessmerlin — the server now treats them like Merlin for this command, so the response matches.</li>
                 <li>Added: Admin command to verify a user's email address. </li>
                 <li>Improved: use cryptographically secure random number generator. </li>
             </ul>


### PR DESCRIPTION
## Summary
- Real Merlin's `/guessmerlin` attempts return *"Merlin cannot submit a guess."*, but Melron's were accepted with *"You have guessed that X is Merlin. Good luck!"* because the check compared against the real role rather than `displayRole`.
- The divergent responses let a Melron player unmask themselves with one command, undoing the role's deception.
- Switch the gate (and the role name it interpolates into the error) to `displayRole`, so Melron behaves identically to Merlin here.
- Moregano is unchanged in observable behavior: its `displayRole` is Morgana, which is not in `rolesThatCantGuessMerlin` — same outcome as before, just semantically consistent now.

## Test plan
- [ ] Real Merlin runs `/gm X` → *"Merlin cannot submit a guess."*
- [ ] Melron runs `/gm X` → *"Merlin cannot submit a guess."* (was previously accepted)
- [ ] Real Morgana runs `/gm X` → guess accepted
- [ ] Moregano runs `/gm X` → guess accepted (unchanged)
- [ ] Resistance vanilla / Spy vanilla runs `/gm X` → guess accepted (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)