### PR TITLE
Fixing Timer Abuse Possibility

### DIFF
--- a/src/gameplay/gameEngine/gameTimer.ts
+++ b/src/gameplay/gameEngine/gameTimer.ts
@@ -178,6 +178,10 @@ export class GameTimer {
       phaseObject = this.game.specialPhases[this.game.phase];
     }
 
+    // Check for gamestates where all players should timer vote "yes" to avoid timer abuse
+    const hammerVote =
+      this.game.pickNum === 5 && phaseObject.phase === 'VotingTeam';
+    const missionVote = phaseObject.phase === 'VotingMission';
     // Iterate over each user to figure out who hasn't acted.
     for (let i = 0; i < this.game.playersInGame.length; i++) {
       const buttonSettings: ButtonSettings = phaseObject.buttonSettings(i);
@@ -186,7 +190,7 @@ export class GameTimer {
         phaseObject.getProhibitedIndexesToPick(i);
 
       const buttonsAvailable: string[] = [];
-      if (buttonSettings.red.hidden === false) {
+      if (buttonSettings.red.hidden === false && !hammerVote && !missionVote) {
         buttonsAvailable.push('no');
       }
 

--- a/src/gameplay/gameEngine/gameTimer.ts
+++ b/src/gameplay/gameEngine/gameTimer.ts
@@ -179,8 +179,6 @@ export class GameTimer {
     }
 
     // Check for gamestates where all players should timer vote "yes" to avoid timer abuse
-    const hammerVote =
-      this.game.pickNum === 5 && phaseObject.phase === 'VotingTeam';
     const missionVote = phaseObject.phase === 'VotingMission';
     // Iterate over each user to figure out who hasn't acted.
     for (let i = 0; i < this.game.playersInGame.length; i++) {
@@ -190,7 +188,7 @@ export class GameTimer {
         phaseObject.getProhibitedIndexesToPick(i);
 
       const buttonsAvailable: string[] = [];
-      if (buttonSettings.red.hidden === false && !hammerVote && !missionVote) {
+      if (buttonSettings.red.hidden === false && !missionVote) {
         buttonsAvailable.push('no');
       }
 


### PR DESCRIPTION
This addresses #758 by making it impossible for resistance players to demand all players timer vote on a mission to abuse the fact that they are not permitted to fail a mission on timer.