### PR TITLE
Updating Autospy/Autores Mention Rule

### DIFF
--- a/src/views/rules.ejs
+++ b/src/views/rules.ejs
@@ -199,7 +199,7 @@
       </dt>
       <dt>6. No pasting of relevant game-related text from the server.</dt>
       <dt>7. Intentionally playing suboptimally to spite another player.</dt>
-      <dt>8. Intentionally holding biases towards specific players or claiming to be doing so ("I autores them", "I'm automorging you").</dt>
+      <dt>8. Intentionally holding biases towards specific players or claiming to be doing so, or discussing other players' biases during a game with them ("I autores them", "I'm automorging you", "They always autospy me").</dt>
       <dt>
         9. Having personal metas and claiming them (“I only off app as res”, “I
         only tell the truth”).


### PR DESCRIPTION
A lot of players feel the current rule about "autospying" and "autoressing" is unintuitive or not expansive enough. Exact reading would imply that its OK to discuss autospying or autoressing in general so long as it's not about your own bias - for example it's allowed right now to openly accuse someone else of "autospying" you. Mods have come to think that we might as well just disallow openly accusing autoressing mid-game and it would be for the best.