### PR TITLE
Multiple card changes

### DIFF
--- a/assets/scripts/lobby/buttonEventListeners2.js
+++ b/assets/scripts/lobby/buttonEventListeners2.js
@@ -74,6 +74,7 @@ function greenButtonFunction() {
           assassination: ((parseInt($('#startGameOptionsAssassinationPhaseTimeoutMin').val()) * 60 + parseInt($('#startGameOptionsAssassinationPhaseTimeoutSec').val())) * 1000).toString(),
         },
         anonymousMode: $('#startGameOptionsAnonymousMode')[0].checked,
+        randomizeCardPosition: $('#startGameOptionsRandomizeCardPosition')[0].checked,
       };
 
       socket.emit('startGame', startGameData);

--- a/assets/scripts/lobby/publicData/avalon.js
+++ b/assets/scripts/lobby/publicData/avalon.js
@@ -16,8 +16,8 @@ function runPublicDataAvalon(gameDataInc) {
     }
 
     // Reset cards container
-    $('.playerDiv').find('.cardsContainer')[0].innerHTML = '';
-
+    $('.playerDiv').find('.cardsContainer').html = '';
+    
     // Draw cards:
     for (const key in gd.publicData.cards) {
       if (gd.publicData.cards.hasOwnProperty(key) === true) {
@@ -39,10 +39,24 @@ function runPublicDataAvalon(gameDataInc) {
 
         const padding =
           "<span class='cardObject glyphicon glyphicon-asterisk' style='visibility: hidden;'></span> ";
+        
+        const playerDiv = $('.playerDiv')[index];
+        if (!playerDiv) {
+          console.log('Card index out of bounds', {
+            index, card: key, playerDivCount: $('.playerDiv').length, cardData: gd.publicData.cards[key]
+          });
+          continue;
+        }
+        const cardsContainer = $(playerDiv).find('.cardsContainer')[0];
+        if (!cardsContainer) {
+          console.log('No cardsContainer found for player', {
+            index, card: key, playerDiv
+          });
+          continue;
+        }
 
-        $($('.playerDiv')[index]).find('.cardsContainer')[0].innerHTML += card;
-        $($('.playerDiv')[index]).find('.cardsContainer')[0].innerHTML +=
-          padding;
+        cardsContainer.innerHTML += card;
+        cardsContainer.innerHTML += padding;
 
         // Initialise the tooltip.
         $('.cardObject').tooltip();

--- a/src/gameplay/gameEngine/cards/avalon/ladyOfTheLake.ts
+++ b/src/gameplay/gameEngine/cards/avalon/ladyOfTheLake.ts
@@ -24,10 +24,8 @@ class LadyOfTheLake implements ICard {
     this.thisRoom = thisRoom;
   }
 
-  initialise(): void {
-    this.setHolder(
-      (this.thisRoom.teamLeader + 1) % this.thisRoom.playersInGame.length,
-    );
+  initialise(indexOfPlayerHolding: number): void {
+    this.setHolder(indexOfPlayerHolding);
   }
 
   setHolder(index: number): void {

--- a/src/gameplay/gameEngine/cards/avalon/refOfTheRain.ts
+++ b/src/gameplay/gameEngine/cards/avalon/refOfTheRain.ts
@@ -24,10 +24,8 @@ class RefOfTheRain implements ICard {
     this.thisRoom = thisRoom;
   }
 
-  initialise(): void {
-    this.setHolder(
-      (this.thisRoom.teamLeader + 1) % this.thisRoom.playersInGame.length,
-    );
+  initialise(indexOfPlayerHolding: number): void {
+    this.setHolder(indexOfPlayerHolding);
   }
 
   setHolder(index: number): void {

--- a/src/gameplay/gameEngine/cards/avalon/sireOfTheSea.ts
+++ b/src/gameplay/gameEngine/cards/avalon/sireOfTheSea.ts
@@ -24,16 +24,8 @@ class SireOfTheSea implements ICard {
     this.thisRoom = thisRoom;
   }
 
-  initialise(): void {
-    // If lady of the sea is in the game, give the card to the next person.
-    let addOne = 0;
-    if (this.thisRoom.options.includes('Lady of the Lake')) {
-      addOne = 1;
-    }
-    this.setHolder(
-      (this.thisRoom.teamLeader + 1 + addOne) %
-        this.thisRoom.playersInGame.length,
-    );
+  initialise(indexOfPlayerHolding: number): void {
+    this.setHolder(indexOfPlayerHolding);
   }
 
   setHolder(index: number): void {

--- a/src/gameplay/gameEngine/cards/types.ts
+++ b/src/gameplay/gameEngine/cards/types.ts
@@ -9,7 +9,7 @@ export enum Card {
 export interface ICard {
   card: Card;
 
-  initialise(): void;
+  initialise(indexOfPlayerHolding: number): void;
 
   setHolder(index: number): void;
 

--- a/src/gameplay/gameEngine/game.ts
+++ b/src/gameplay/gameEngine/game.ts
@@ -119,6 +119,8 @@ class Game extends Room {
   anonymizer: Anonymizer = new Anonymizer();
   anonymousMode = false;
 
+  randomizeCardPosition = false;
+
   recoverableComponents: IRecoverable[] = [];
 
   constructor(gameConfig: GameConfig) {
@@ -171,6 +173,12 @@ class Game extends Room {
   configureAnonymousMode(anonymousMode: boolean): void {
     if (this.gameStarted === false) {
       this.anonymousMode = anonymousMode;
+    }
+  }
+
+  configurerandomizeCardPosition(randomizeCardPosition: boolean): void {
+    if (this.gameStarted == false) {
+      this.randomizeCardPosition = randomizeCardPosition;
     }
   }
 
@@ -580,14 +588,46 @@ class Game extends Room {
       }
     }
 
+    if (this.randomizeCardPosition) {
+      this.sendText('The game is running with randomized card positions.', 'gameplay-text');
+    }
+
     // seed the starting data into the VH
     for (let i = 0; i < this.playersInGame.length; i++) {
       this.voteHistory[this.playersInGame[i].request.user.username] = [];
     }
-
+    
     // Initialise all the Cards
-    for (let i = 0; i < this.cardKeysInPlay.length; i++) {
-      this.specialCards[this.cardKeysInPlay[i]].initialise();
+    const cardPosition = {};
+    const numPlayers = this.playersInGame.length;
+
+    let availableIndexes = [];
+    for (let i = 0; i < numPlayers; i++) {
+      availableIndexes.push(i);
+    }
+
+    if (this.randomizeCardPosition) {
+      availableIndexes = shuffleArray(availableIndexes);
+    }
+
+    for (const cardKey of this.cardKeysInPlay) {
+      if (this.randomizeCardPosition) {
+        cardPosition[cardKey] = availableIndexes.shift();
+      }
+      else {
+        const firstCardPosition = (this.hammer + 5 + numPlayers) % numPlayers;
+        let offset = 0;
+        if (cardKey === Card.SireOfTheSea && this.cardKeysInPlay.includes(Card.LadyOfTheLake))
+          offset++;
+        if (cardKey === Card.RefOfTheRain && this.cardKeysInPlay.includes(Card.LadyOfTheLake))
+          offset++;
+        if (cardKey === Card.RefOfTheRain && this.cardKeysInPlay.includes(Card.SireOfTheSea))
+          offset++;
+        
+        cardPosition[cardKey] = (firstCardPosition + offset) % numPlayers;
+      }
+
+      this.specialCards[cardKey].initialise(cardPosition[cardKey]);
     }
 
     this.distributeGameData();
@@ -1378,6 +1418,7 @@ class Game extends Room {
       gameMode: this.gameMode,
       roomCreationType: this.roomCreationType,
       anonymousMode: this.anonymousMode,
+      randomizeCardPosition: this.randomizeCardPosition,
       botUsernames,
 
       playerUsernamesOrdered: getUsernamesOfPlayersInGame(this),

--- a/src/gameplay/gameEngine/room.ts
+++ b/src/gameplay/gameEngine/room.ts
@@ -603,6 +603,7 @@ class Room {
     gameMode: string,
     timeouts: Timeouts,
     anonymousMode: boolean,
+    randomizeCardPosition: boolean,
   ) {
     if (this.gameStarted === true) {
       return false;
@@ -651,6 +652,7 @@ class Room {
       timeouts.assassination,
     )}`;
     rolesInStr += `<br>Anonymous mode: ${anonymousMode}`;
+    rolesInStr += `<br>Randomize card position: ${randomizeCardPosition}`;
 
     this.sendText('The game is starting!', 'gameplay-text');
 

--- a/src/sockets/sockets.ts
+++ b/src/sockets/sockets.ts
@@ -1578,6 +1578,7 @@ function startGame(data) {
   const options = data.options;
   const gameMode = data.gameMode;
   const anonymousMode = data.anonymousMode;
+  const randomizeCardPosition = data.randomizeCardPosition;
   const timeoutsStr = data.timeouts;
 
   // start the game
@@ -1614,11 +1615,13 @@ function startGame(data) {
   ) {
     rooms[this.request.user.inRoomId].configureTimeouts(timeouts);
     rooms[this.request.user.inRoomId].configureAnonymousMode(anonymousMode);
+    rooms[this.request.user.inRoomId].configurerandomizeCardPosition(randomizeCardPosition);
     rooms[this.request.user.inRoomId].hostTryStartGame(
       options,
       gameMode,
       timeouts,
       anonymousMode,
+      randomizeCardPosition,
     );
   }
 }

--- a/src/views/lobby.ejs
+++ b/src/views/lobby.ejs
@@ -974,6 +974,9 @@
         <br>
         <label>Anonymous mode:</label>
         <input type="checkbox" name="startGameOptionsAnonymousMode" id="startGameOptionsAnonymousMode"/>
+        <br>
+        <label>Randomize card position:</label>
+        <input type="checkbox" name="startGameOptionsRandomizeCardPosition" id="startGameOptionsRandomizeCardPosition"/>
 
         <div class="row">
           <div


### PR DESCRIPTION
- Move card initialization to game.ts. (instead if within each individual card script)
- Fix unaccounted card overlap check. (Lady of the Lake and Sire of the Sea had a check to avoid overlap, but Ref of the Rain lacked this check.)
- Add lobby option to randomize starting card positions. (Cards will never overlap)
- Fix card container reset issues.