### PR TITLE
Removes "Melron/Moregano saw:" message when roles are absent

### DIFF
--- a/src/gameplay/gameEngine/game.ts
+++ b/src/gameplay/gameEngine/game.ts
@@ -2084,7 +2084,7 @@ class Game extends Room {
   private announceIllusionsIfAny() {
     // Melron
     const melronRole = this.specialRoles[Role.Melron];
-    if (melronRole) {
+    if (this.roleKeysInPlay.includes('Melron')) {
       const data = melronRole.getPublicGameData();
       if (data.spiesMelronSaw) {
         this.sendText(
@@ -2096,7 +2096,7 @@ class Game extends Room {
 
     // Moregano
     const moreganoRole = this.specialRoles[Role.Moregano];
-    if (moreganoRole) {
+    if (this.roleKeysInPlay.includes('Moregano')) {
       const data = moreganoRole.getPublicGameData();
       if (data.spiesMoreganoSaw)
       {

--- a/src/gameplay/gameEngine/game.ts
+++ b/src/gameplay/gameEngine/game.ts
@@ -2083,28 +2083,21 @@ class Game extends Room {
 
   private announceIllusionsIfAny() {
     // Melron
-    const melronRole = this.specialRoles[Role.Melron];
-    if (this.roleKeysInPlay.includes('Melron')) {
-      const data = melronRole.getPublicGameData();
-      if (data.spiesMelronSaw) {
-        this.sendText(
-          `Melron saw as spies: ${data.spiesMelronSaw.join(', ')}`,
-          'gameplay-text-blue',
-        );
-      }
+    if (this.roleKeysInPlay.includes(Role.Melron)) {
+      const data = this.specialRoles[Role.Melron].getPublicGameData();
+      this.sendText(
+        `Melron saw as spies: ${data.spiesMelronSaw.join(', ')}`,
+        'gameplay-text-blue',
+      );
     }
 
     // Moregano
-    const moreganoRole = this.specialRoles[Role.Moregano];
-    if (this.roleKeysInPlay.includes('Moregano')) {
-      const data = moreganoRole.getPublicGameData();
-      if (data.spiesMoreganoSaw)
-      {
-        this.sendText(
-          `Moregano saw as spies: ${data.spiesMoreganoSaw.join(', ')}`,
-          'gameplay-text-red',
-        );
-      }
+    if (this.roleKeysInPlay.includes(Role.Moregano)) {
+      const data = this.specialRoles[Role.Moregano].getPublicGameData();
+      this.sendText(
+        `Moregano saw as spies: ${data.spiesMoreganoSaw.join(', ')}`,
+        'gameplay-text-red',
+      );
     }
   }
 

--- a/src/views/changelog.ejs
+++ b/src/views/changelog.ejs
@@ -21,6 +21,7 @@
                 <li>Improved: No need to enter the password to a room again if you've already successfully joined the room before. Thanks Nixon!</li>
                 <li>Added: Percivals now appear on the Members page. Thanks Nixon!</li>
                 <li>Fixed: Melron can no longer see the true spy team as spies. Thanks Nixon!</li>
+                <li>Fixed: Server no longer incorrectly sends melron/moregano viewed data when they aren't in play. Thanks Ba3henov!</li>
             </ul>
         </li>
 


### PR DESCRIPTION
Fixes #765 