### PR TITLE
Adding percival section to Communtity/Members page

### DIFF
--- a/src/routes/community.ts
+++ b/src/routes/community.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import User from '../models/user';
-import { ModStore } from '../modsadmins/roles';
+import { ModStore, PercivalStore } from '../modsadmins/roles';
 
 const router = Router();
 
@@ -10,6 +10,7 @@ router.get('/community', async (req, res) => {
   const getall = req.query.getall !== undefined;
 
   const modsArray = ModStore.getRoleArray();
+  const percivalArray = PercivalStore.getRoleArray();
   const filteredModsArray = modsArray.filter((mod) => mod != 'pronub');
 
   const users = await User.find({
@@ -21,10 +22,12 @@ router.get('/community', async (req, res) => {
     .sort({ totalGamesPlayed: -1 });
 
   const mods = await User.find({ usernameLower: { $in: filteredModsArray } });
+  const percivals = await User.find({ usernameLower: { $in: percivalArray } });
 
   res.render('community', {
     users,
     mods,
+    percivals,
     // @ts-ignore
     currentUser: req.user,
     headerActive: 'community',

--- a/src/views/changelog.ejs
+++ b/src/views/changelog.ejs
@@ -16,6 +16,13 @@
     <h1>Changelog!</h1>
     <ul class="list-group" id="my-list">
         <li class="list-group-item">
+            <strong>16-06-2026: </strong>
+            <ul>
+                <li>Added: Added Percivals section to Members page. Thanks Nixon!</li>
+            </ul>
+        </li>
+
+        <li class="list-group-item">
             <strong>10-06-2026: </strong>
             <ul>
                 <li>Improved: Dynamic site permission system. Thanks Nixon!</li>

--- a/src/views/community.ejs
+++ b/src/views/community.ejs
@@ -199,6 +199,43 @@
       <% }); %>
     </table>
 
+    <table class="myTable">
+      <h4>Percivals</h4>
+      <tr>
+        <th>Username</th>
+        <th>Res Avatar</th>
+        <th>Spy Avatar</th>
+        <th class="nat">Nationality</th>
+        <th class="bio">Biography</th>
+        <th class="games">#Games</th>
+      </tr>
+
+      <% percivals.forEach(function(percival){ %>
+      <tr>
+        <td>
+          <a class="username" href="/profile/<%= percival.username %>">
+            <%= percival.username %>
+          </a>
+        </td>
+        <%if (percival.avatarImgRes===null) { %>
+        <td><img src="/avatars/base-res.svg" /></td>
+        <% } else { %>
+        <td><img src="<%= percival.avatarImgRes %>" /></td>
+        <% } %> <%if (percival.avatarImgSpy===null) { %>
+        <td><img src="/avatars/base-spy.svg" /></td>
+        <% } else { %>
+        <td><img src="<%= percival.avatarImgSpy %>" /></td>
+        <% } %> <%if (percival.nationality==="" ) { %>
+        <td class="nat">United Nations</td>
+        <% } else { %>
+        <td class="nat"><%= percival.nationality %></td>
+        <% } %>
+        <td class="cell"><%- percival.biography %></td>
+        <td class="games"><%= percival.totalGamesPlayed %></td>
+      </tr>
+      <% }); %>
+    </table>
+
     <table class="myTable" id="userTable">
       <h4>Players</h4>
       <tr>


### PR DESCRIPTION
Unlike with Moderators, there has never been a user-friendly way for users to view the current list of Percivals, and with the addition of dynamic roles, the list cannot be viewed via examining GitHub code either. This fixes this issue by creating a Percivals section on the Members page.