### PR TITLE
QOL Improvement for password rooms

### DIFF
--- a/src/gameplay/gameEngine/room.ts
+++ b/src/gameplay/gameEngine/room.ts
@@ -100,8 +100,8 @@ class Room {
     this.botSockets = [];
 
     // Arrays containing lower cased usernames
-    this.kickedPlayers = [];
-    this.loggedInPlayers = [];
+    this.kickedPlayers = new Set();
+    this.loggedInPlayers = new Set();
 
     // Phases Cards and Roles to use
     this.commonPhases = this.initialiseGameDependencies(commonPhases);
@@ -122,7 +122,7 @@ class Room {
         TOStore.isRole(socket.request.user.username) ||
         PercivalStore.isRole(socket.request.user.username) ||
         isAdmin(socket.request.user.username) ||
-        this.loggedInPlayers.includes(socket.request.user.username.toLowerCase())
+        this.loggedInPlayers.has(socket.request.user.username.toLowerCase())
       )
     ) {
       // if the room has a password and user hasn't put one in yet
@@ -144,7 +144,7 @@ class Room {
       ) {
         if (this.joinPassword === inputPassword) {
           // console.log("Correct password!");
-          this.loggedInPlayers.push(socket.request.user.username.toLowerCase());
+          this.loggedInPlayers.add(socket.request.user.username.toLowerCase());
         } else {
           // console.log("Wrong password!");
 
@@ -195,7 +195,7 @@ class Room {
     }
 
     // If they were kicked and banned
-    if (this.kickedPlayers.indexOf(socketUsername.toLowerCase()) !== -1) {
+    if (this.kickedPlayers.has(socketUsername.toLowerCase())) {
       socket.emit(
         'danger-alert',
         'The host has kicked you from this room. You cannot join.',
@@ -313,8 +313,8 @@ class Room {
         this.playerLeaveRoom(socketOfTarget);
       }
 
-      // Add to kickedPlayers array
-      this.kickedPlayers.push(username.toLowerCase());
+      // Add to kickedPlayers set
+      this.kickedPlayers.add(username.toLowerCase());
       const kickMsg = `Player ${username} has been kicked by ${this.host}.`;
       this.sendText(kickMsg, 'server-text');
       // console.log(kickMsg);

--- a/src/gameplay/gameEngine/room.ts
+++ b/src/gameplay/gameEngine/room.ts
@@ -80,6 +80,10 @@ class Room {
   lockJoin = false;
   readyPrompt: ReadyPrompt;
 
+  // Arrays containing lower cased usernames
+  kickedPlayers: Set<string> = new Set();
+  playersWithRoomPassword: Set<string> = new Set();
+
   constructor(roomConfig: RoomConfig) {
     // Expand config
     this.host = roomConfig.host;
@@ -98,10 +102,6 @@ class Room {
     this.allSockets = [];
     this.socketsOfPlayers = [];
     this.botSockets = [];
-
-    // Arrays containing lower cased usernames
-    this.kickedPlayers = new Set();
-    this.loggedInPlayers = new Set();
 
     // Phases Cards and Roles to use
     this.commonPhases = this.initialiseGameDependencies(commonPhases);
@@ -122,7 +122,7 @@ class Room {
         TOStore.isRole(socket.request.user.username) ||
         PercivalStore.isRole(socket.request.user.username) ||
         isAdmin(socket.request.user.username) ||
-        this.loggedInPlayers.has(socket.request.user.username.toLowerCase())
+        this.playersWithRoomPassword.has(socket.request.user.username.toLowerCase())
       )
     ) {
       // if the room has a password and user hasn't put one in yet
@@ -143,12 +143,8 @@ class Room {
         (socket.isBotSocket === undefined || socket.isBotSocket === false)
       ) {
         if (this.joinPassword === inputPassword) {
-          // console.log("Correct password!");
-          this.loggedInPlayers.add(socket.request.user.username.toLowerCase());
+          this.playersWithRoomPassword.add(socket.request.user.username.toLowerCase());
         } else {
-          // console.log("Wrong password!");
-
-          // socket.emit("danger-alert", "The password you have inputted is incorrect.");
           socket.emit('wrongRoomPassword');
           socket.emit('changeView', 'lobby');
           return false;

--- a/src/gameplay/gameEngine/room.ts
+++ b/src/gameplay/gameEngine/room.ts
@@ -11,7 +11,7 @@ import { Role } from './roles/types';
 import { Phase } from './phases/types';
 import { millisToStr } from '../../util/time';
 import { RoomPlayer } from './types';
-import { ModStore, TOStore } from '../../modsadmins/roles';
+import { ModStore, TOStore, PercivalStore } from '../../modsadmins/roles';
 import { isAdmin } from '../../modsadmins/admins';
 
 export class RoomConfig {
@@ -101,6 +101,7 @@ class Room {
 
     // Arrays containing lower cased usernames
     this.kickedPlayers = [];
+    this.loggedInPlayers = [];
 
     // Phases Cards and Roles to use
     this.commonPhases = this.initialiseGameDependencies(commonPhases);
@@ -114,12 +115,14 @@ class Room {
       `${socket.request.user.username} has joined room ${this.roomId}`,
     );
 
-    // check if the player is a moderator or TO or admin, if so bypass
+    // check if the player is on the mod team, or already logged in, if so bypass
     if (
       !(
         ModStore.isRole(socket.request.user.username) ||
         TOStore.isRole(socket.request.user.username) ||
-        isAdmin(socket.request.user.username)
+        PercivalStore.isRole(socket.request.user.username) ||
+        isAdmin(socket.request.user.username) ||
+        this.loggedInPlayers.includes(socket.request.user.username.toLowerCase())
       )
     ) {
       // if the room has a password and user hasn't put one in yet
@@ -141,6 +144,7 @@ class Room {
       ) {
         if (this.joinPassword === inputPassword) {
           // console.log("Correct password!");
+          this.loggedInPlayers.push(socket.request.user.username.toLowerCase());
         } else {
           // console.log("Wrong password!");
 

--- a/src/views/changelog.ejs
+++ b/src/views/changelog.ejs
@@ -16,6 +16,13 @@
     <h1>Changelog!</h1>
     <ul class="list-group" id="my-list">
         <li class="list-group-item">
+            <strong>28-06-2026: </strong>
+            <ul>
+                <li>Improved: No need to enter the password to a room again if you've already successfully joined the room before. Thanks Nixon!</li>
+            </ul>
+        </li>
+
+        <li class="list-group-item">
             <strong>10-06-2026: </strong>
             <ul>
                 <li>Improved: Dynamic site permission system. Thanks Nixon!</li>


### PR DESCRIPTION
Random disconnections and other interruptions can make it annoying and inconvenient for players to reenter private rooms. This small change stores successful password entries, so nobody ever has to enter a room's password more than one time.